### PR TITLE
fix: event error

### DIFF
--- a/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
+++ b/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,6 +28,7 @@ public class EventController {
 
     private final EventService eventService;
 
+    @PreAuthorize("hasAuthority('ADMIN')")
     @Operation(summary = "쿠폰 이벤트 생성", description = "관리자가 쿠폰 이벤트를 생성합니다.",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "쿠폰 생성 요청 DTO",
@@ -42,6 +44,7 @@ public class EventController {
         return ResultResponse.of(ResultCode.EVENT_CREATE_SUCCESS, response);
     }
 
+    @PreAuthorize("hasRole('HOST')")
     @Operation(summary = "티켓 이벤트 생성", description = "주최자가 티켓 이벤트를 생성합니다.",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "티켓 이벤트 생성 요청 DTO",
@@ -62,7 +65,7 @@ public class EventController {
                     @ApiResponse(responseCode = "200", description = "응모 성공",
                             content = @Content(schema = @Schema(implementation = TicketApplyResponseDto.class))),
                     @ApiResponse(responseCode = "400", description = "포인트 부족, 중복 응모 등 예외 발생")})
-    @PostMapping("/ticket/{eventId}")
+    @GetMapping("/ticket/{eventId}")
     public ResultResponse<TicketApplyResponseDto> applyTicketEvent(@PathVariable Long eventId) {
         TicketApplyResponseDto response = eventService.applyTicketEvent(eventId);
         return ResultResponse.of(ResultCode.EVENT_CREATE_SUCCESS, response);
@@ -84,6 +87,7 @@ public class EventController {
                     @ApiResponse(responseCode = "200", description = "조회 성공",
                             content = @Content(schema = @Schema(implementation = PagingResponse.class))),
                     @ApiResponse(responseCode = "400", description = "유효하지 않은 이벤트 타입")})
+    @PostMapping
     public ResultResponse<PagingResponse<EventListResponseDto>> getEventList(@RequestParam("type") EventType eventType,
                                                                              @RequestParam("page") int page,
                                                                              @RequestParam("size") int size) {
@@ -95,7 +99,7 @@ public class EventController {
     @Operation(summary = "티켓 이벤트 상세 조회", description = "티켓 이벤트의 상세 정보를 조회합니다.",
             responses = {@ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = TicketEventDetailResponseDto.class)))})
-    @GetMapping("/ticket/{eventId}")
+    @GetMapping("/ticket/detail/{eventId}")
     public ResultResponse<TicketEventDetailResponseDto> getTicketEventDetail(@PathVariable Long eventId) {
         TicketEventDetailResponseDto detail = eventService.getTicketEventDetail(eventId);
         return ResultResponse.of(ResultCode.EVENT_INFO_SUCCESS, detail);

--- a/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
+++ b/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
@@ -116,9 +116,9 @@ public class EventController {
             responses = {@ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = EventListResponseDto.class)))})
     @GetMapping("/random")
-    public ResultResponse<List<EventListResponseDto>> getRandomEvents() {
-        List<EventListResponseDto> events = eventService.getRandomOngoingEvents();
-        return ResultResponse.of(ResultCode.EVENT_INFO_SUCCESS, events);
+    public ResultResponse<PagingResponse<TicketEventResponseDto>> getRandomEvents() {
+        PagingResponse<TicketEventResponseDto> dto = eventService.findRandomOngoingEvents();
+        return ResultResponse.of(ResultCode.EVENT_INFO_SUCCESS, dto);
     }
 
 }

--- a/src/main/java/com/profect/tickle/domain/event/dto/response/SeatProjection.java
+++ b/src/main/java/com/profect/tickle/domain/event/dto/response/SeatProjection.java
@@ -1,0 +1,8 @@
+package com.profect.tickle.domain.event.dto.response;
+
+public record SeatProjection(
+        Long eventId,
+        Long performanceId,
+        String eventName,
+        String seatNumber
+) {}

--- a/src/main/java/com/profect/tickle/domain/event/dto/response/TicketEventDetailResponseDto.java
+++ b/src/main/java/com/profect/tickle/domain/event/dto/response/TicketEventDetailResponseDto.java
@@ -3,10 +3,12 @@ package com.profect.tickle.domain.event.dto.response;
 import com.profect.tickle.domain.reservation.entity.SeatGrade;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
+
 public record TicketEventDetailResponseDto(
 
         @Schema(description = "이벤트 ID", example = "1")
-        Long eventId,
+        Long id,
 
         @Schema(description = "공연 이름", example = "뮤지컬 <레미제라블>")
         String performanceTitle,
@@ -18,10 +20,10 @@ public record TicketEventDetailResponseDto(
         Short performanceRuntime,
 
         @Schema(description = "공연 기간", example = "2025-08-01")
-        String performanceDate,
+        LocalDate performanceDate,
 
         @Schema(description = "이벤트 좌석 코드", example = "A12")
-        String seatCode,
+        String seatNumber,
 
         @Schema(description = "좌석 등급", example = "VIP")
         SeatGrade seatGrade,

--- a/src/main/java/com/profect/tickle/domain/event/dto/response/TicketEventResponseDto.java
+++ b/src/main/java/com/profect/tickle/domain/event/dto/response/TicketEventResponseDto.java
@@ -16,14 +16,12 @@ public record TicketEventResponseDto(
         String eventName,
 
         @Schema(description = "좌석 정보", example = "A열 3번")
-        String ticketSeat
-) {
+        String seatNumber
+)  {
     public static TicketEventResponseDto from(Event event, Long performanceId) {
         String seatNumber = event.getSeat().getSeatNumber(); // ex: "A45"
-
-        String row = seatNumber.replaceAll("[0-9]", "");     // "A"
-        String number = seatNumber.replaceAll("[^0-9]", ""); // "45"
-
+        String row = seatNumber.replaceAll("[0-9]", "");
+        String number = seatNumber.replaceAll("[^0-9]", "");
         String ticketSeat = row + "열 " + number + "번";
 
         return new TicketEventResponseDto(

--- a/src/main/java/com/profect/tickle/domain/event/entity/Event.java
+++ b/src/main/java/com/profect/tickle/domain/event/entity/Event.java
@@ -104,7 +104,7 @@ public class Event {
     }
 
     public void accumulate(Short perPrice) {
-        if (this.status.getCode() != 5L) {
+        if (this.status.getId() != 5) {
             throw new BusinessException(ErrorCode.EVENT_NOT_IN_PROGRESS);}
         this.accrued += perPrice;
     }

--- a/src/main/java/com/profect/tickle/domain/event/entity/Event.java
+++ b/src/main/java/com/profect/tickle/domain/event/entity/Event.java
@@ -3,6 +3,8 @@ package com.profect.tickle.domain.event.entity;
 import com.profect.tickle.domain.event.dto.request.TicketEventCreateRequestDto;
 import com.profect.tickle.domain.performance.entity.Performance;
 import com.profect.tickle.domain.reservation.entity.Seat;
+import com.profect.tickle.global.exception.BusinessException;
+import com.profect.tickle.global.exception.ErrorCode;
 import com.profect.tickle.global.status.Status;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -102,6 +104,8 @@ public class Event {
     }
 
     public void accumulate(Short perPrice) {
+        if (this.status.getCode() != 5L) {
+            throw new BusinessException(ErrorCode.EVENT_NOT_IN_PROGRESS);}
         this.accrued += perPrice;
     }
 

--- a/src/main/java/com/profect/tickle/domain/event/entity/Event.java
+++ b/src/main/java/com/profect/tickle/domain/event/entity/Event.java
@@ -102,7 +102,7 @@ public class Event {
     }
 
     public void accumulate(Short perPrice) {
-        this.goalPrice += perPrice;
+        this.accrued += perPrice;
     }
 
     public void updateStatus(Status status) {

--- a/src/main/java/com/profect/tickle/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/profect/tickle/domain/event/mapper/EventMapper.java
@@ -12,9 +12,9 @@ public interface EventMapper {
     List<CouponListResponseDto> findCouponEventList(@Param("size") int size, @Param("offset") int offset);
     TicketEventDetailResponseDto findTicketEventDetail(@Param("eventId") Long eventId);
     List<TicketListResponseDto> searchTicketEvents(@Param("keyword") String keyword, @Param("size") int size, @Param("offset") int offset);
-    List<EventListResponseDto> findRandomOngoingEvents();
+    List<SeatProjection> findRandomOngoingEvents(int size, int offset);
 
     int countSearchTicketEvents(@Param("keyword") String keyword);
     long countCouponEvents(); // 페이징처리 시, 전체 쿠폰의 갯수를 알기 위한 메서드
-    long countTicketEvents(); // 페이징처리 시, 전체 티켓의 갯수를 알기 위한 메서드
+    Integer countTicketEvents(); // 페이징처리 시, 전체 티켓의 갯수를 알기 위한 메서드
 }

--- a/src/main/java/com/profect/tickle/domain/event/service/EventService.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/EventService.java
@@ -23,7 +23,7 @@ public interface EventService {
 
     PagingResponse<TicketListResponseDto> searchTicketEvents(String keyword, int page, int size);
 
-    List<EventListResponseDto> getRandomOngoingEvents();
+    PagingResponse<TicketEventResponseDto> findRandomOngoingEvents();
 
     PagingResponse<CouponResponseDto> getMyCoupons(int page, int size);
 

--- a/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
@@ -99,7 +99,9 @@ public class EventServiceImpl implements EventService {
         Event event = getEventOrThrow(eventId);
         Member member = getMemberOrThrow();
 
-        //deductPoint(member, event, eventTarget);
+        Point point = member.deductPoint(event.getPerPrice(), eventTarget);
+        pointRepository.save(point);
+
         event.accumulate(event.getPerPrice());
 
         boolean isWinner = (event.getAccrued().equals(event.getGoalPrice()));

--- a/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
@@ -70,7 +70,7 @@ public class EventServiceImpl implements EventService {
         );
         couponRepository.save(coupon);
 
-        Status status = getStatusOrThrow(9L);
+        Status status = getStatusOrThrow(4L);
         Event event = Event.create(status, coupon, request.name());
 
         eventRepository.save(event);
@@ -173,7 +173,8 @@ public class EventServiceImpl implements EventService {
         }
 
         coupon.decreaseCount();
-        couponReceivedRepository.save(CouponReceived.create(member, coupon));
+        Status issuedStatus = getStatusOrThrow(17L);
+        couponReceivedRepository.save(CouponReceived.create(member, coupon, issuedStatus));
     }
 
     @Override

--- a/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
@@ -185,10 +185,31 @@ public class EventServiceImpl implements EventService {
         return PagingResponse.from(list, page, size, total);
     }
 
-    @Override
     @Transactional(readOnly = true)
-    public List<EventListResponseDto> getRandomOngoingEvents() {
-        return new ArrayList<>(eventMapper.findRandomOngoingEvents());
+    public PagingResponse<TicketEventResponseDto> findRandomOngoingEvents() {
+        int page = 0;
+        int size = 5;
+        int offset = page * size;
+
+        List<SeatProjection> raw = eventMapper.findRandomOngoingEvents(size, offset);
+        long total = eventMapper.countTicketEvents();
+
+        List<TicketEventResponseDto> content = raw.stream()
+                .map(r -> {
+                    String row = r.seatNumber().replaceAll("[0-9]", "");
+                    String number = r.seatNumber().replaceAll("[^0-9]", "");
+                    String formattedSeat = row + "열 " + number + "번";
+
+                    return new TicketEventResponseDto(
+                            r.eventId(),
+                            r.performanceId(),
+                            r.eventName(),
+                            formattedSeat
+                    );
+                })
+                .toList();
+
+        return PagingResponse.from(content, page, size, total);
     }
 
     @Override

--- a/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
@@ -33,9 +33,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
@@ -105,6 +105,7 @@ public class EventServiceImpl implements EventService {
         boolean isWinner = (event.getAccrued().equals(event.getGoalPrice()));
         if (isWinner) {
             Seat seat = getSeatOrThrow(event.getSeat().getId());
+            event.updateStatus(getStatusOrThrow(6L));
 
             seat.assignTo(member);
             Reservation reservation = Reservation.create(

--- a/src/main/java/com/profect/tickle/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/profect/tickle/domain/member/controller/MyPageController.java
@@ -6,6 +6,7 @@ import com.profect.tickle.global.paging.PagingResponse;
 import com.profect.tickle.global.response.ResultCode;
 import com.profect.tickle.global.response.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/mypage")
+@Tag(name = "마이페이지", description = "마이페이지 관련 API입니다.")
 public class MyPageController {
 
     private final EventService eventService;

--- a/src/main/java/com/profect/tickle/domain/member/entity/CouponReceived.java
+++ b/src/main/java/com/profect/tickle/domain/member/entity/CouponReceived.java
@@ -50,12 +50,12 @@ public class CouponReceived {
         this.updatedAt = Instant.now();
     }
 
-    private CouponReceived(Member member, Coupon coupon) {
+    private CouponReceived(Member member, Coupon coupon, Status status) {
         this.member = member;
         this.coupon = coupon;
+        this.status = status;
     }
-
-    public static CouponReceived create(Member member, Coupon coupon) {
-        return new CouponReceived (member, coupon);
+    public static CouponReceived create(Member member, Coupon coupon, Status status) {
+        return new CouponReceived(member, coupon, status);
     }
 }

--- a/src/main/java/com/profect/tickle/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/profect/tickle/global/security/config/SecurityConfig.java
@@ -81,7 +81,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.POST, "/api/v1/sign-in").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/performance/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/event/**").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/api/v1/event/coupon").hasRole(MemberRole.ADMIN.name())
+                                .requestMatchers(HttpMethod.POST, "/api/v1/event/coupon").hasAuthority("ADMIN")
                                 .anyRequest().authenticated()
                 )
                 .sessionManagement(session ->

--- a/src/main/resources/mapper/event/CouponReceivedMapper.xml
+++ b/src/main/resources/mapper/event/CouponReceivedMapper.xml
@@ -13,7 +13,7 @@
                  JOIN coupon c ON cr.coupon_id = c.coupon_id
         WHERE cr.member_id = #{memberId}
           AND c.coupon_valid > CURRENT_DATE
-        And cr.status.id = 17
+        And cr.status_id = 17
         ORDER BY cr.coupon_received_created_at DESC
             LIMIT #{size} OFFSET #{offset}
     </select>
@@ -24,6 +24,6 @@
                  JOIN coupon c ON cr.coupon_id = c.coupon_id
         WHERE cr.member_id = #{memberId}
           AND c.coupon_valid > CURRENT_DATE
-          And cr.status.id = 17
+          And cr.status_id = 17
     </select>
 </mapper>

--- a/src/main/resources/mapper/event/EventMapper.xml
+++ b/src/main/resources/mapper/event/EventMapper.xml
@@ -7,9 +7,9 @@
 
     <select id="findCouponEventList" resultType="com.profect.tickle.domain.event.dto.response.CouponListResponseDto">
         SELECT
-            c.coupon_id AS couponId,
+            c.coupon_id AS id,
             c.coupon_name AS name,
-            c.coupon_valid AS validDate
+            c.coupon_rate AS rate
         FROM coupon c
         ORDER BY c.coupon_created_at DESC
             LIMIT #{size} OFFSET #{offset}
@@ -30,7 +30,7 @@
         LIMIT #{size} OFFSET #{offset}
     </select>
 
-    <select id="countCouponEvents" resultType="int">
+    <select id="countCouponEvents" resultType="long">
         SELECT COUNT(*)
         FROM coupon c
         WHERE EXISTS (

--- a/src/main/resources/mapper/event/EventMapper.xml
+++ b/src/main/resources/mapper/event/EventMapper.xml
@@ -53,21 +53,21 @@
     <select id="findTicketEventDetail"
             resultType="com.profect.tickle.domain.event.dto.response.TicketEventDetailResponseDto">
         SELECT
-            e.event_id AS eventId,
+            e.event_id AS id,
             p.performance_title AS performanceTitle,
-            p.performance_place AS performancePlace,
+            h.hall_address AS performancePlace,
+            p.performance_runtime AS performanceRuntime,
             p.performance_date AS performanceDate,
-            p.performance_time AS performanceRuntime,
-            s.seat_code AS seatCode,
-            sc.seat_class_grade AS seatClassGrade,
+            s.seat_number AS seatNumber,
+            s.seat_grade AS seatGrade,
             e.event_per_price AS perPrice,
             p.performance_img AS performanceImg,
-            st.status_name AS eventStatusName
+            st.status_description AS eventStatusName
         FROM event e
                  JOIN seat s ON e.seat_id = s.seat_id
-                 JOIN seat_class sc ON s.seat_class_id = sc.seat_class_id
                  JOIN performance p ON s.performance_id = p.performance_id
                  JOIN status st ON e.status_id = st.status_id
+                 JOIN hall h ON p.hall_id = h.hall_id
         WHERE e.event_id = #{eventId}
     </select>
 

--- a/src/main/resources/mapper/event/EventMapper.xml
+++ b/src/main/resources/mapper/event/EventMapper.xml
@@ -73,14 +73,17 @@
 
     <select id="searchTicketEvents" resultType="com.profect.tickle.domain.event.dto.response.TicketListResponseDto">
         SELECT
-            e.event_id AS eventId,
+            e.event_id AS id,
             e.event_name AS name,
-            e.event_created_at AS createdAt
+            e.event_per_price AS perPrice,
+            p.performance_img AS img
         FROM event e
-                 JOIN status s ON e.status_id = s.status_id
+                 JOIN seat s ON e.seat_id = s.seat_id
+                 JOIN performance p ON s.performance_id = p.performance_id
+                 JOIN status st ON e.status_id = st.status_id
         WHERE e.event_type = 1
-          AND s.status_code IN (100, 101)
-          AND e.event_name LIKE CONCAT('%', #{keyword}, '%')
+          AND st.status_code IN (100, 101)
+          AND e.event_name LIKE '%' || #{keyword} || '%'
         ORDER BY e.event_created_at DESC
             LIMIT #{size}
         OFFSET #{offset}
@@ -92,7 +95,7 @@
                  JOIN status s ON e.status_id = s.status_id
         WHERE e.event_type = 1
           AND s.status_code IN (100, 101)
-          AND e.event_name LIKE CONCAT('%', #{keyword}, '%')
+          AND e.event_name LIKE '%' || #{keyword} || '%'
     </select>
 
     <select id="findRandomOngoingEvents" resultType="com.profect.tickle.domain.event.dto.response.EventListResponseDto">

--- a/src/main/resources/mapper/event/EventMapper.xml
+++ b/src/main/resources/mapper/event/EventMapper.xml
@@ -98,15 +98,19 @@
           AND e.event_name LIKE '%' || #{keyword} || '%'
     </select>
 
-    <select id="findRandomOngoingEvents" resultType="com.profect.tickle.domain.event.dto.response.EventListResponseDto">
+    <select id="findRandomOngoingEvents"
+            resultType="com.profect.tickle.domain.event.dto.response.SeatProjection">
         SELECT
             e.event_id AS eventId,
-            e.event_name AS name,
-            e.event_created_at AS createdAt
+            p.performance_id AS performanceId,
+            e.event_name AS eventName,
+            s.seat_number AS seatNumber
         FROM event e
-                 JOIN status s ON e.status_id = s.status_id
-        WHERE s.status_code = 101
-        ORDER BY RAND()
-            LIMIT 5
+                 JOIN status st ON e.status_id = st.status_id
+                 JOIN seat s ON e.seat_id = s.seat_id
+                 JOIN performance p ON s.performance_id = p.performance_id
+        WHERE st.status_id IN (4, 5)
+        ORDER BY RANDOM()
+            LIMIT #{size} OFFSET #{offset}
     </select>
 </mapper>


### PR DESCRIPTION
## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 
- #58 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

## 이벤트 에러 해결

### 1. 티켓 이벤트 응모 시, 누적 금액이 아닌 목표 금액이 오르는 에러

현재 티켓 이벤트 응모 시, 누적 금액이 아닌 목표 금액이 오르는 에러가 발생하는 것을 확인할 수 있었습니다.

필드 오탈자 에러를 확인하고 고쳐 에러를 해결하였습니다.

**`수정 전`**

```java
    //EventServiceImpl.java
    @Override
    @Transactional
    public TicketApplyResponseDto applyTicketEvent(Long eventId) {
			   .
			   .
			   .
        event.accumulate(event.getPerPrice()); // 응모 시, 이벤트의 누적 금액이 오르는 메서드
	        }
		}
```

```java
    //Event.java
    public void accumulate(Short perPrice) {
        this.goalPrice += perPrice;
    }
```

**`수정 후`**

```java
    //Event.java
    public void accumulate(Short perPrice) {
        this.accrued += perPrice;
    }
```

### 2. 진행중이 아닌 이벤트에 참여 시 발생하는 예외처리 구현

진행중이 아닌 이벤트에도 참여가 가능하도록 로직이 작성되어있어, 이에 맞는 예외처리를 구현하였습니다.

**`수정 전`** 

```java
    //Event.java
    public void accumulate(Short perPrice) {
        this.accrued += perPrice;
    }
```

**`수정 후`**

```java
    public void accumulate(Short perPrice) {
        if (this.status.getCode() != 5L) {
            throw new BusinessException(ErrorCode.EVENT_NOT_IN_PROGRESS);}
        this.accrued += perPrice;
    }
```

### 3.  이벤트 마감 시 상태코드 변경

이벤트가 종료되었음에도 불구하고 계속 진행됨으로 남아있어 계속 응모를 할 수 있는 에러를 발견해 해결하였습니다.

**`수정 전`** 

event.status 업데이트의 부재로 인해 발생하는 에러였습니다.

```java
    //EventServiceImpl.java
    @Override
    @Transactional
    public TicketApplyResponseDto applyTicketEvent(Long eventId) {
		    .
		    .
		    .		 
        if (isWinner) {
            Seat seat = getSeatOrThrow(event.getSeat().getId());

            seat.assignTo(member);
            Reservation reservation = Reservation.create(
                    member,
                    seat.getPerformance(),
                    getStatusOrThrow(9L),
                    "100",
                    event.getGoalPrice(),
                    true);

            reservation.assignSeat(seat);

            reservationRepository.save(reservation);
        }
    }
```

**`수정 후`**

```java
    //EventServiceImpl.java
    @Override
    @Transactional
    public TicketApplyResponseDto applyTicketEvent(Long eventId) {
		    .
		    .
		    .		 
        if (isWinner) {
            Seat seat = getSeatOrThrow(event.getSeat().getId());
            event.updateStatus(getStatusOrThrow(6L)); // 상태 업데이트 명시

            seat.assignTo(member);
            Reservation reservation = Reservation.create(
                    member,
                    seat.getPerformance(),
                    getStatusOrThrow(9L),
                    "100",
                    event.getGoalPrice(),
                    true);

            reservation.assignSeat(seat);

            reservationRepository.save(reservation);
        }
    }
```

### 4. 티켓 이벤트 키워드 조회 오류

키워드가 존재하는 이벤트를 검색하여도 500 오류가 뜨는 에러를 확인하였습니다.

Mybatis 지식이 미숙하여 발생한 에러였습니다…

**`수정 전`** 

```sql
    //EventMapper.java
    <select id="searchTicketEvents" resultType="com.profect.tickle.domain.event.dto.response.TicketListResponseDto">
        SELECT
            e.event_id AS eventId,
            e.event_name AS name,
            e.event_created_at AS createdAt
        FROM event e
                 JOIN status s ON e.status_id = s.status_id
        WHERE e.event_type = 1
          AND s.status_code IN (100, 101)
          AND e.event_name LIKE CONCAT('%', #{keyword}, '%')
        ORDER BY e.event_created_at DESC
            LIMIT #{size}
        OFFSET #{offset}
    </select>
    }
```

```java
//TicketListResponseDto.java
public record TicketListResponseDto(
        Long id,
        String name,
        Short perPrice,
        String img
) implements EventListResponseDto {

    @Override
    public Long getEventId() {
        return id;
    }

    @Override
    public String getName() {
        return name;
    }
}
```

1. DTO가 Record 일 시, 모두 SELECT에서 매핑되어야한다.

resultType을 TicketListResponseDto로 지정하였으나, Dto가 class가 아닌 record타입이기 때문에 **4개의 필드가 모두 SELECT에서 매핑되어야만** MyBatis가 객체를 만들 수 있습니다.

2. **필드 누락으로 인한 BindingException**
- Mapper에서는 `e.event_id AS eventId`로, 별칭을 이용해 eventId라는 필드와 매핑을 시도했으나, Dto에서 id를 갖는 필드명은 `id` 여서 매핑이 되지 않는 오류가 있었습니다.
- Mapper에서 매핑하고자 했던 createAt은 Dto에 없는 필드여서 발생하는 오류가 있었습니다.

```java
e.event_id AS eventId,
e.event_name AS name,
e.event_created_at AS createdAt
```

- Dto의 img에 Performance_img 값을 넣어주어야했으나, Performance와의 Join이 없어 값이 누락되는 오류가 있었습니다.
3. **`AND e.event_name LIKE CONCAT('%', #{keyword}, '%')`** 으로 키워드와 알맞는 이벤트를 추출하려고 했으나, Postgres는 CONCAT 메서드를 지원하지 않아 발생하는 오류가 있었습니다.
LIKE 문과 || 연산자를 통해 키워드를 추출하도록 하였습니다.

**`수정 후`**

```sql
    //EventMapper.java
    <select id="searchTicketEvents" resultType="com.profect.tickle.domain.event.dto.response.TicketListResponseDto">
        SELECT
            e.event_id AS id,
            e.event_name AS name,
            e.event_per_price AS perPrice,
            p.performance_img AS img
        FROM event e
                 JOIN seat s ON e.seat_id = s.seat_id
                 JOIN performance p ON s.performance_id = p.performance_id
                 JOIN status st ON e.status_id = st.status_id
        WHERE e.event_type = 1
          AND st.status_code IN (100, 101)
          AND e.event_name LIKE '%' || #{keyword} || '%'
        ORDER BY e.event_created_at DESC
            LIMIT #{size}
        OFFSET #{offset}
    </select>
```
### 5. 티켓 이벤트 상세 내용 조회 오류

이벤트id를 받아, 상세 내용을 반환하는 api의 500 오류를 확인하였습니다.

위와 마찬가지로 Mybatis 지식이 미숙하여 발생한 에러였습니다.

**`수정 전`** 

![스크린샷 2025-08-04 오후 3.36.55.png](attachment:1a84f94f-45a9-49b9-8b19-5542baf48eaa:스크린샷_2025-08-04_오후_3.36.55.png)

```sql
  //EventMapper
   <select id="findTicketEventDetail"
            resultType="com.profect.tickle.domain.event.dto.response.TicketEventDetailResponseDto">
        SELECT
            e.event_id AS eventId,
            p.performance_title AS performanceTitle,
            p.performance_place AS performancePlace,
            p.performance_date AS performanceDate,
            p.performance_time AS performanceRuntime,
            s.seat_code AS seatCode,
            sc.seat_class_grade AS seatClassGrade,
            e.event_per_price AS perPrice,
            p.performance_img AS performanceImg,
            st.status_name AS eventStatusName
        FROM event e
                 JOIN seat s ON e.seat_id = s.seat_id
                 JOIN seat_class sc ON s.seat_class_id = sc.seat_class_id
                 JOIN performance p ON s.performance_id = p.performance_id
                 JOIN status st ON e.status_id = st.status_id
        WHERE e.event_id = #{eventId}
    </select>
```

```java
public record TicketEventDetailResponseDto(

        @Schema(description = "이벤트 ID", example = "1")
        Long id,

        @Schema(description = "공연 이름", example = "뮤지컬 <레미제라블>")
        String performanceTitle,

        @Schema(description = "공연 장소", example = "예술의전당 오페라극장")
        String performancePlace,

        @Schema(description = "공연 시간", example = "110")
        Short performanceRuntime,

        @Schema(description = "공연 기간", example = "2025-08-01")
        LocalDate performanceDate,

        @Schema(description = "이벤트 좌석 코드", example = "A12")
        String seatNumber,

        @Schema(description = "좌석 등급", example = "VIP")
        SeatGrade seatGrade,

        @Schema(description = "응모 가격", example = "5000")
        Short perPrice,

        @Schema(description = "공연 이미지 URL", example = "https://example.com/perf.jpg")
        String performanceImg,

        @Schema(description = "이벤트 상태명", example = "진행중")
        String eventStatusName
) {}
```

1. SeatClass 테이블이 사라짐에 따라 JOIN을 삭제한 뒤, Seat에서 seat_number과 seat_grade를 가져오도록 구현하였습니다. 
2. performance 테이블에 place라는 장소 필드가 없어서 발생하는 오류 해결하였습니다.
hall을 Join하여 hall_address로 대체하여 공연 장소에 대한 값을 불러옵니다.
`performance_place AS performancePlace` → `h.hall_address AS performancePlace` 로 변경
3. status 테이블 속성 값 오탈자로 인한 오류를 해결하였습니다.
`st.status_name AS eventStatusName` → `st.status_description AS eventStatusName` 로 변경

**`수정 후`** 

성공적으로 이벤트에 대한 상세정보가 반환되는 것을 확인할 수 있었습니다.

![스크린샷 2025-08-04 오후 3.52.38.png](attachment:dd8efd20-2053-4f03-b3e2-6513d72e8a68:스크린샷_2025-08-04_오후_3.52.38.png)

```sql
    <select id="findTicketEventDetail"
            resultType="com.profect.tickle.domain.event.dto.response.TicketEventDetailResponseDto">
        SELECT
            e.event_id AS id,
            p.performance_title AS performanceTitle,
            h.hall_address AS performancePlace,
            p.performance_runtime AS performanceRuntime,
            p.performance_date AS performanceDate,
            s.seat_number AS seatNumber,
            s.seat_grade AS seatGrade,
            e.event_per_price AS perPrice,
            p.performance_img AS performanceImg,
            st.status_description AS eventStatusName
        FROM event e
                 JOIN seat s ON e.seat_id = s.seat_id
                 JOIN performance p ON s.performance_id = p.performance_id
                 JOIN status st ON e.status_id = st.status_id
                 JOIN hall h ON p.hall_id = h.hall_id
        WHERE e.event_id = #{eventId}
    </select>
```

## 누락 기능 추가 구현

### 쿠폰 발급 누락

쿠폰을 발급을 받았으나, Status의 필드 수정으로 인해 Member에게 제대로 발급되지 않는 오류를 확인했습니다.  코드 수정 후 멤버에게 쿠폰이 발급되는 것을 확인할 수 있었습니다.

**`수정 후`**

```sql
    @Override
    @Transactional
    public void issueCoupon(Long eventId) {
		    .
		    .
		    .
        Status issuedStatus = getStatusOrThrow(17L); //쿠폰 발급 상태 추가
        couponReceivedRepository.save(CouponReceived.create(member, coupon, issuedStatus));
    }
```

![스크린샷 2025-08-04 오후 6.14.51.png](attachment:d0b78a8c-719a-4a87-8706-3e48eb9e1689:스크린샷_2025-08-04_오후_6.14.51.png)


## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

오류나는곳이 있다면 말씀해주셔요!!!