### PR TITLE
feat: 예매 취소 기능 구현

### DIFF
--- a/src/main/java/com/profect/tickle/domain/point/entity/Point.java
+++ b/src/main/java/com/profect/tickle/domain/point/entity/Point.java
@@ -59,6 +59,10 @@ public class Point {
         return new Point(member, -amount, target, generateInternalOrderId());
     }
 
+    public static Point refund(Member member, int amount, PointTarget target) {
+        return new Point(member, amount, target, generateInternalOrderId());
+    }
+
     private static String generateInternalOrderId() {
         return "deduct_" + System.currentTimeMillis();
     }

--- a/src/main/java/com/profect/tickle/domain/point/entity/PointTarget.java
+++ b/src/main/java/com/profect/tickle/domain/point/entity/PointTarget.java
@@ -3,5 +3,6 @@ package com.profect.tickle.domain.point.entity;
 public enum PointTarget {
     RESERVATION,
     EVENT,
-    CHARGE
+    CHARGE,
+    REFUND
 }

--- a/src/main/java/com/profect/tickle/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/controller/ReservationController.java
@@ -2,10 +2,12 @@ package com.profect.tickle.domain.reservation.controller;
 
 import com.profect.tickle.domain.reservation.dto.request.ReservationCompletionRequest;
 import com.profect.tickle.domain.reservation.dto.request.SeatPreemptionRequest;
+import com.profect.tickle.domain.reservation.dto.response.ReservationCancelResponse;
 import com.profect.tickle.domain.reservation.dto.response.ReservationCompletionResponse;
 import com.profect.tickle.domain.reservation.dto.response.ReservationInfoResponse;
 import com.profect.tickle.domain.reservation.dto.response.SeatInfoResponse;
 import com.profect.tickle.domain.reservation.dto.response.SeatPreemptionResponse;
+import com.profect.tickle.domain.reservation.service.ReservationHistoryService;
 import com.profect.tickle.domain.reservation.service.ReservationInfoService;
 import com.profect.tickle.domain.reservation.service.ReservationService;
 import com.profect.tickle.domain.reservation.service.SeatPreemptionService;
@@ -15,6 +17,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,6 +34,7 @@ public class ReservationController {
     private final SeatPreemptionService seatPreemptionService;
     private final ReservationInfoService reservationInfoService;
     private final ReservationService reservationService;
+    private final ReservationHistoryService reservationHistoryService;
 
     @GetMapping("/{performanceId}/seats")
     public ResponseEntity<List<SeatInfoResponse>> getPerformanceSeats(
@@ -62,6 +66,16 @@ public class ReservationController {
             @RequestBody @Valid ReservationCompletionRequest request) {
 
         ReservationCompletionResponse response = reservationService.completeReservation(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{reservationId}")
+    public ResponseEntity<ReservationCancelResponse> cancelReservation(
+            @PathVariable Long reservationId) {
+
+        ReservationCancelResponse response = reservationHistoryService
+                .cancelReservation(reservationId);
+
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/profect/tickle/domain/reservation/dto/response/ReservationCancelResponse.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/dto/response/ReservationCancelResponse.java
@@ -1,0 +1,33 @@
+package com.profect.tickle.domain.reservation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ReservationCancelResponse {
+    private boolean success;
+    private String message;
+    private Integer refundAmount;               // 환불 금액
+    private Instant cancelledAt;                // 취소 일시
+    
+    public static ReservationCancelResponse success(Integer refundAmount) {
+        return ReservationCancelResponse.builder()
+                .success(true)
+                .message("예매가 취소되었습니다.")
+                .refundAmount(refundAmount)
+                .cancelledAt(Instant.now())
+                .build();
+    }
+    
+    public static ReservationCancelResponse failure(String message) {
+        return ReservationCancelResponse.builder()
+                .success(false)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/profect/tickle/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/entity/Reservation.java
@@ -70,6 +70,10 @@ public class Reservation {
         seat.assignReservation(this); // 연관관계 편의 메서드
     }
 
+    public void changeStatusTo(Status status) {
+        this.status = status;
+    }
+
     private static String generateReservationCode() {
         String uuidPart = UUID.randomUUID().toString().replace("-", "").substring(0, 6).toUpperCase();
         String dateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));

--- a/src/main/java/com/profect/tickle/domain/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/entity/ReservationStatus.java
@@ -1,0 +1,19 @@
+package com.profect.tickle.domain.reservation.entity;
+
+import lombok.Getter;
+
+public enum ReservationStatus {
+    PAID("결제완료", 9L),
+    CANCELED("취소됨",9L);
+
+    @Getter
+    private final String description;
+
+    @Getter
+    private final Long id;
+
+    ReservationStatus(String description, Long id) {
+        this.description = description;
+        this.id = id;
+    }
+}

--- a/src/main/java/com/profect/tickle/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/repository/ReservationRepository.java
@@ -1,9 +1,12 @@
 package com.profect.tickle.domain.reservation.repository;
 
 import com.profect.tickle.domain.reservation.entity.Reservation;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    Optional<Reservation> findByIdAndMemberId(Long reservationId, Long memberId);
 }

--- a/src/main/java/com/profect/tickle/domain/reservation/repository/SeatRepository.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/repository/SeatRepository.java
@@ -37,4 +37,6 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     @Query("SELECT s FROM Seat s WHERE s.preemptionToken = :token")
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<Seat> findByPreemptionTokenWithLock(@Param("token") String preemptionToken);
+
+    List<Seat> findByReservationId(Long reservationId);
 }

--- a/src/main/java/com/profect/tickle/domain/reservation/service/ReservationHistoryService.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/service/ReservationHistoryService.java
@@ -1,0 +1,109 @@
+package com.profect.tickle.domain.reservation.service;
+
+import com.profect.tickle.domain.member.entity.Member;
+import com.profect.tickle.domain.member.repository.MemberRepository;
+import com.profect.tickle.domain.point.entity.Point;
+import com.profect.tickle.domain.point.entity.PointTarget;
+import com.profect.tickle.domain.point.repository.PointRepository;
+import com.profect.tickle.domain.reservation.dto.response.ReservationCancelResponse;
+import com.profect.tickle.domain.reservation.entity.Reservation;
+import com.profect.tickle.domain.reservation.entity.ReservationStatus;
+import com.profect.tickle.domain.reservation.entity.Seat;
+import com.profect.tickle.domain.reservation.entity.SeatStatus;
+import com.profect.tickle.domain.reservation.repository.ReservationRepository;
+import com.profect.tickle.domain.reservation.repository.SeatRepository;
+import com.profect.tickle.global.security.util.SecurityUtil;
+import com.profect.tickle.global.status.Status;
+import com.profect.tickle.global.status.repository.StatusRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReservationHistoryService {
+
+    private final ReservationRepository reservationRepository;
+    private final SeatRepository seatRepository;
+    private final StatusRepository statusRepository;
+    private final MemberRepository memberRepository;
+    private final PointRepository pointRepository;
+
+    @Transactional
+    public ReservationCancelResponse cancelReservation(Long reservationId) {
+
+        Long userId = SecurityUtil.getSignInMemberId();
+
+        try {
+            Reservation reservation = reservationRepository.findByIdAndMemberId(reservationId,
+                            userId)
+                    .orElseThrow(() -> new IllegalArgumentException("예매 내역을 찾을 수 없습니다."));
+
+            // 취소 가능 여부 확인
+            if (!isCancellable(reservation)) {
+                return ReservationCancelResponse.failure("취소할 수 없는 예매입니다.");
+            }
+
+            // 좌석 상태 변경 (예매완료 → 예매가능)
+            List<Seat> seats = seatRepository.findByReservationId(reservationId);
+            updateSeatsToAvailable(seats);
+
+            // 예매 상태 변경
+            Status canceled = statusRepository.findById(ReservationStatus.CANCELED.getId())
+                    .orElseThrow();
+
+            reservation.changeStatusTo(canceled);
+
+            reservationRepository.save(reservation);
+
+            // 포인트 환불
+            Integer refundAmount = reservation.getPrice();
+
+            Member member = memberRepository.findById(userId)
+                    .orElseThrow();
+
+            Point point = Point.refund(member, refundAmount, PointTarget.REFUND);
+            pointRepository.save(point);
+
+            member.addPoint(refundAmount);
+
+            return ReservationCancelResponse.success(refundAmount);
+
+        } catch (Exception e) {
+            return ReservationCancelResponse.failure(e.getMessage());
+        }
+    }
+
+    private boolean isCancellable(Reservation reservation) {
+        if (!Objects.equals(reservation.getStatus().getId(), ReservationStatus.PAID.getId())) {
+            return false;
+        }
+
+        // 공연 시작일까지만 취소 가능
+        Instant performanceStartDate = reservation.getPerformance().getStartDate();
+        Instant today = Instant.now();
+
+        return today.isBefore(performanceStartDate);
+    }
+
+    private void updateSeatsToAvailable(List<Seat> seats) {
+        Status availableStatus = statusRepository.findById(SeatStatus.AVAILABLE.getId())
+                .orElseThrow(() -> new IllegalStateException("예매가능 상태를 찾을 수 없습니다."));
+
+        for (Seat seat : seats) {
+            cancelSeatsOfReservation(seat, availableStatus);
+        }
+
+        seatRepository.saveAll(seats);
+    }
+
+    private void cancelSeatsOfReservation(Seat seat, Status availableStatus) {
+        seat.assignReservation(null);
+        seat.assignTo(null);
+        seat.setStatusTo(availableStatus);
+    }
+}

--- a/src/main/java/com/profect/tickle/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/service/ReservationService.java
@@ -12,6 +12,7 @@ import com.profect.tickle.domain.reservation.dto.request.ReservationCompletionRe
 import com.profect.tickle.domain.reservation.dto.response.ReservationCompletionResponse;
 import com.profect.tickle.domain.reservation.dto.response.ReservedSeatInfo;
 import com.profect.tickle.domain.reservation.entity.Reservation;
+import com.profect.tickle.domain.reservation.entity.ReservationStatus;
 import com.profect.tickle.domain.reservation.entity.Seat;
 import com.profect.tickle.domain.reservation.repository.ReservationRepository;
 import com.profect.tickle.domain.reservation.repository.SeatRepository;
@@ -145,7 +146,7 @@ public class ReservationService {
 
         Performance performance = seats.get(0).getPerformance();
 
-        Status paidStatus = statusRepository.findById(9L)
+        Status paidStatus = statusRepository.findById(ReservationStatus.PAID.getId())
                 .orElseThrow();
 
         Reservation reservation = Reservation.create(


### PR DESCRIPTION
## 📌 연관된 이슈
closes #69 

## 📝작업 내용

- 예매 상태 및 공연 시작 시간을 기준으로 취소 가능 여부 검증
- 좌석 상태를 '예매가능'으로 변경하고 예약 정보 해제
- 예매 상태를 'CANCELED'로 변경
- 사용자의 포인트를 환불하고 환불 이력 저장


## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
