### PR TITLE
feat: 선점 시간 만료 좌석 자동 해제 기능 구현

### DIFF
--- a/src/main/java/com/profect/tickle/domain/reservation/service/SeatPreemptionReleaser.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/service/SeatPreemptionReleaser.java
@@ -1,0 +1,28 @@
+package com.profect.tickle.domain.reservation.service;
+
+import com.profect.tickle.domain.reservation.repository.SeatRepository;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SeatPreemptionReleaser {
+
+    private final SeatRepository seatRepository;
+
+    @Transactional
+    public void releaseExpiredPreemptions() {
+        Instant now = Instant.now();
+        int count = seatRepository.clearExpiredPreemptionsBulk(now);
+
+        if (count > 0) {
+            log.info("벌크로 {}개 좌석 선점 해제", count);
+        } else {
+            log.debug("해제된 좌석 없음");
+        }
+    }
+}

--- a/src/main/java/com/profect/tickle/domain/reservation/service/SeatReleaseScheduler.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/service/SeatReleaseScheduler.java
@@ -1,0 +1,19 @@
+package com.profect.tickle.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SeatReleaseScheduler {
+
+    private final SeatPreemptionReleaser releaser;
+
+    @Scheduled(cron = "*/10 * * * * *")
+    public void releaseExpiredSeats() {
+        releaser.releaseExpiredPreemptions();
+    }
+}


### PR DESCRIPTION
## 📌 연관된 이슈
closes #79 

## 📝작업 내용

선점 시간 만료된 좌석을 다시 예매 가능한 좌석으로 상태를 바꾸는 기능을 구현했습니다.

현재는 MVP인 만큼 가장 간단하게 스케줄러를 사용하여
- 현재 시간 보다 만료시간이 이전일 경우 선점 관련 값을 업데이트 하는 쿼리를
- 스케줄러를 사용해서 10초마다 한번씩 보내고 있습니다.

추후 이벤트 기반 처리, redis 적용 등 다양한 방법을 통해 선점 만료 시간에 따라 실시간으로 처리 될 수 있게 바꿔보려 합니다.


## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
