### PR TITLE
refactor: 계약 Entity 수정

### DIFF
--- a/src/main/java/com/profect/tickle/domain/contract/dto/ContractResponseDto.java
+++ b/src/main/java/com/profect/tickle/domain/contract/dto/ContractResponseDto.java
@@ -14,7 +14,8 @@ public class ContractResponseDto {
     private Long contractId;           // 계약 고유번호
     private Long userId;               // 회원 고유번호
     private BigDecimal contractCharge; // 계약 수수료
-    private Instant contractCreatedAt; // 계약 생성일
+    private Instant contractEffectiveFrom; // 계약 생성일
+    private Instant contractEffectiveTo; // 계약 종료일
 
     // Entity → DTO 변환
     public static ContractResponseDto fromEntity(Contract entity) {
@@ -22,7 +23,8 @@ public class ContractResponseDto {
                 .contractId(entity.getContractId())
                 .userId(entity.getMember().getId())
                 .contractCharge(entity.getCharge())
-                .contractCreatedAt(entity.getCreatedAt())
+                .contractEffectiveFrom(entity.getEffectiveFrom())
+                .contractEffectiveTo(entity.getEffectiveTo())
                 .build();
     }
 }

--- a/src/main/java/com/profect/tickle/domain/contract/entity/Contract.java
+++ b/src/main/java/com/profect/tickle/domain/contract/entity/Contract.java
@@ -33,14 +33,23 @@ public class Contract {
             nullable = false)
     private BigDecimal charge;  // 계약 수수료
 
-    @Column(name = "contract_created_at", nullable = false, updatable = false)
-    private Instant createdAt;  // 계약 생성일
+    @Column(name = "contract_effective_from", nullable = false, updatable = false)
+    private Instant effectiveFrom;  // 계약 적용시작일
+
+    @Column(name = "contract_effective_to")
+    private Instant effectiveTo;    // 계약 적용종료일
+
+    @PrePersist
+    public void prePersist() {
+        if(this.effectiveFrom == null) {
+            this.effectiveFrom = Instant.now();
+        }
+    }
 
     public static Contract createContract(Member newMember, BigDecimal hostContractCharge) {
         return Contract.builder()
                 .member(newMember)
                 .charge(hostContractCharge)
-                .createdAt(newMember.getCreatedAt())
                 .build();
     }
 }


### PR DESCRIPTION
## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 
- #102 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

정산 리팩터링 도중에 계약 Entity 수정이 필요하여 수정했습니다.

## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

계약 테이블에서 수수료율 불러와서 계산 진행하게 되는데,
추후 수수료율이 수정되면 변경 전/후 수수료율 구분할 수가 없어서 컬럼 추가했습니다.
그리고 사업자 1명당 1건의 계약 관련 데이터가 있고, update 하는 방식에서
재계약(수수료율 변경)시 새로운 데이터가 insert 되는 방식으로 설계 변경했습니다.
아래는 예시고, 월요일에 회의 고고합시다.

예시)
1) 2025-07-10 회원 생성
계약고유번호 1 / 사업자1 / 3% / 2025-07-10(계약시작일) / null(계약종료일)

2) 2025-08-08 재계약
계약고유번호 1 / 사업자1 / 3% / 2025-07-10(계약시작일) / 2025-08-08(계약종료일 update)
계약고유번호 2 / 사업자1 / 5% / 2025-08-09(계약시작일) / null