### PR TITLE
feat:이벤트 API 추가

### DIFF
--- a/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
+++ b/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
@@ -58,7 +58,7 @@ public class EventController {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 좌석 또는 상태 ID")})
     @PostMapping("/ticket")
     public ResultResponse<TicketEventResponseDto> createTicketEvent(@Valid @RequestBody TicketEventCreateRequestDto request) {
-        TicketEventResponseDto response = eventService.createTicketEvent(request);
+        TicketEventResponseDto response = eventService.screateTicketEvent(request);
         return ResultResponse.of(ResultCode.EVENT_CREATE_SUCCESS, response);
     }
 

--- a/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
+++ b/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
@@ -47,7 +47,7 @@ public class EventController {
     }
 
     @PreAuthorize("hasRole('HOST')")
-    @Operation(summary = "티켓 이벤트 생성", description = "주최자가 티켓 이벤트를 생성합니다.",
+    @Operation(summary = "티켓 이벤트 직접 생성", description = "주최자가 티켓 이벤트를 생성합니다.",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "티켓 이벤트 생성 요청 DTO",
                     required = true,
@@ -108,7 +108,7 @@ public class EventController {
     @Operation(summary = "티켓 이벤트 상세 조회", description = "티켓 이벤트의 상세 정보를 조회합니다.",
             responses = {@ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = TicketEventDetailResponseDto.class)))})
-    @GetMapping("/ticket/detail/{eventId}")
+    @GetMapping("/ticket/{eventId}")
     public ResultResponse<TicketEventDetailResponseDto> getTicketEventDetail(@PathVariable Long eventId) {
         TicketEventDetailResponseDto detail = eventService.getTicketEventDetail(eventId);
         return ResultResponse.of(ResultCode.EVENT_INFO_SUCCESS, detail);

--- a/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
+++ b/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
@@ -40,6 +40,7 @@ public class EventController {
                     @ApiResponse(responseCode = "200", description = "이벤트 생성 성공",
                             content = @Content(schema = @Schema(implementation = CouponResponseDto.class))),
                     @ApiResponse(responseCode = "400", description = "중복된 쿠폰 이름 등 유효성 예외")})
+
     @PostMapping("/coupon")
     public ResultResponse<CouponResponseDto> createCoupon(@Valid @RequestBody CouponCreateRequestDto request) {
         CouponResponseDto response = eventService.createCouponEvent(request);
@@ -56,9 +57,10 @@ public class EventController {
                     @ApiResponse(responseCode = "200", description = "이벤트 생성 성공",
                             content = @Content(schema = @Schema(implementation = TicketEventResponseDto.class))),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 좌석 또는 상태 ID")})
+
     @PostMapping("/ticket")
     public ResultResponse<TicketEventResponseDto> createTicketEvent(@Valid @RequestBody TicketEventCreateRequestDto request) {
-        TicketEventResponseDto response = eventService.screateTicketEvent(request);
+        TicketEventResponseDto response = eventService.createTicketEvent(request);
         return ResultResponse.of(ResultCode.EVENT_CREATE_SUCCESS, response);
     }
 

--- a/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
+++ b/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
@@ -4,6 +4,7 @@ import com.profect.tickle.domain.event.dto.response.*;
 import com.profect.tickle.domain.event.dto.request.CouponCreateRequestDto;
 import com.profect.tickle.domain.event.dto.request.TicketEventCreateRequestDto;
 import com.profect.tickle.domain.event.entity.EventType;
+import com.profect.tickle.domain.event.service.CouponService;
 import com.profect.tickle.domain.event.service.EventService;
 import com.profect.tickle.global.paging.PagingResponse;
 import com.profect.tickle.global.response.ResultCode;
@@ -27,6 +28,7 @@ import java.util.List;
 public class EventController {
 
     private final EventService eventService;
+    private final CouponService couponService;
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @Operation(summary = "쿠폰 이벤트 생성", description = "관리자가 쿠폰 이벤트를 생성합니다.",
@@ -82,12 +84,19 @@ public class EventController {
         return ResultResponse.of(ResultCode.COUPON_ISSUE_SUCCESS, "[이벤트 쿠폰 지급 완료]: eventId = " + eventId);
     }
 
+    @Operation(summary = "쿠폰 이벤트 상세 조회", description = "특정 쿠폰 ID에 해당하는 쿠폰 이벤트 정보를 반환합니다.")
+    @GetMapping("/coupon/{couponId}")
+    public ResultResponse<CouponListResponseDto> getSpecialCouponDetail(@PathVariable Long couponId) {
+        CouponListResponseDto dto = couponService.getSpecialCouponDetailById(couponId);
+        return ResultResponse.of(ResultCode.EVENT_INFO_SUCCESS, dto);
+    }
+
     @Operation(summary = "이벤트 목록 조회", description = "쿠폰 또는 티켓 이벤트를 페이징으로 조회합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공",
                             content = @Content(schema = @Schema(implementation = PagingResponse.class))),
                     @ApiResponse(responseCode = "400", description = "유효하지 않은 이벤트 타입")})
-    @PostMapping
+    @GetMapping
     public ResultResponse<PagingResponse<EventListResponseDto>> getEventList(@RequestParam("type") EventType eventType,
                                                                              @RequestParam("page") int page,
                                                                              @RequestParam("size") int size) {

--- a/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
+++ b/src/main/java/com/profect/tickle/domain/event/controller/EventController.java
@@ -67,7 +67,7 @@ public class EventController {
                     @ApiResponse(responseCode = "200", description = "응모 성공",
                             content = @Content(schema = @Schema(implementation = TicketApplyResponseDto.class))),
                     @ApiResponse(responseCode = "400", description = "포인트 부족, 중복 응모 등 예외 발생")})
-    @GetMapping("/ticket/{eventId}")
+    @PostMapping("/ticket/{eventId}")
     public ResultResponse<TicketApplyResponseDto> applyTicketEvent(@PathVariable Long eventId) {
         TicketApplyResponseDto response = eventService.applyTicketEvent(eventId);
         return ResultResponse.of(ResultCode.EVENT_CREATE_SUCCESS, response);

--- a/src/main/java/com/profect/tickle/domain/event/dto/request/CouponCreateRequestDto.java
+++ b/src/main/java/com/profect/tickle/domain/event/dto/request/CouponCreateRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
+import java.time.Instant;
 import java.time.LocalDate;
 
 @Schema(description = "할인쿠폰 이벤트 생성 요청 DTO")
@@ -27,6 +28,6 @@ public record CouponCreateRequestDto(
         Short rate,
 
         @Future(message = "과거, 당일은 유효기간으로 지정될 수 없습니다.")
-        @Schema(description = "유효기간 (만료일)", example = "2025-08-31")
-        LocalDate valid
+        @Schema(description = "유효 기간", example = "2025-08-31T00:00:00+09:00")  // ← 여기 포인트
+        Instant validDate
 ) {}

--- a/src/main/java/com/profect/tickle/domain/event/dto/response/CouponListResponseDto.java
+++ b/src/main/java/com/profect/tickle/domain/event/dto/response/CouponListResponseDto.java
@@ -2,22 +2,19 @@ package com.profect.tickle.domain.event.dto.response;
 
 import com.profect.tickle.domain.event.entity.Coupon;
 
+import java.time.Instant;
+
 public record CouponListResponseDto (
         Long id,
         String name,
-        Short rate
+        Short rate,
+        Long eventId,
+        Instant validDate
 ) implements EventListResponseDto {
-    public static CouponListResponseDto from(Coupon coupon) {
-        return new CouponListResponseDto(
-                coupon.getId(),
-                coupon.getName(),
-                coupon.getRate());
-    }
     @Override
     public Long getEventId() {
-        return id;
+        return eventId;
     }
-
     @Override
     public String getName() {
         return name;

--- a/src/main/java/com/profect/tickle/domain/event/dto/response/CouponResponseDto.java
+++ b/src/main/java/com/profect/tickle/domain/event/dto/response/CouponResponseDto.java
@@ -3,6 +3,7 @@ package com.profect.tickle.domain.event.dto.response;
 import com.profect.tickle.domain.event.entity.Coupon;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.Instant;
 import java.time.LocalDate;
 
 @Schema(description = "할인쿠폰 생성 응답 DTO")
@@ -17,7 +18,7 @@ public record CouponResponseDto(
         short couponRate,
 
         @Schema(description = "유효기간")
-        LocalDate couponValid
+        Instant couponValid
 ) {
     public static CouponResponseDto from(Coupon coupon) {
         return new CouponResponseDto(

--- a/src/main/java/com/profect/tickle/domain/event/dto/response/EventListResponseDto.java
+++ b/src/main/java/com/profect/tickle/domain/event/dto/response/EventListResponseDto.java
@@ -1,5 +1,7 @@
 package com.profect.tickle.domain.event.dto.response;
 
+import java.time.Instant;
+
 public interface EventListResponseDto {
     Long getEventId();
     String getName();

--- a/src/main/java/com/profect/tickle/domain/event/dto/response/SeatProjection.java
+++ b/src/main/java/com/profect/tickle/domain/event/dto/response/SeatProjection.java
@@ -1,8 +1,14 @@
 package com.profect.tickle.domain.event.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
 public record SeatProjection(
         Long eventId,
         Long performanceId,
         String eventName,
-        String seatNumber
+        String seatNumber,
+        Instant startDate,
+        Instant endDate
 ) {}

--- a/src/main/java/com/profect/tickle/domain/event/dto/response/TicketEventDetailResponseDto.java
+++ b/src/main/java/com/profect/tickle/domain/event/dto/response/TicketEventDetailResponseDto.java
@@ -3,6 +3,7 @@ package com.profect.tickle.domain.event.dto.response;
 import com.profect.tickle.domain.reservation.entity.SeatGrade;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.Instant;
 import java.time.LocalDate;
 
 public record TicketEventDetailResponseDto(
@@ -20,7 +21,7 @@ public record TicketEventDetailResponseDto(
         Short performanceRuntime,
 
         @Schema(description = "공연 기간", example = "2025-08-01")
-        LocalDate performanceDate,
+        Instant performanceDate,
 
         @Schema(description = "이벤트 좌석 코드", example = "A12")
         String seatNumber,

--- a/src/main/java/com/profect/tickle/domain/event/dto/response/TicketEventResponseDto.java
+++ b/src/main/java/com/profect/tickle/domain/event/dto/response/TicketEventResponseDto.java
@@ -1,7 +1,10 @@
 package com.profect.tickle.domain.event.dto.response;
 
 import com.profect.tickle.domain.event.entity.Event;
+import com.profect.tickle.domain.performance.entity.Performance;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
 
 @Schema(description = "티켓 이벤트 응답 DTO")
 public record TicketEventResponseDto(
@@ -16,19 +19,28 @@ public record TicketEventResponseDto(
         String eventName,
 
         @Schema(description = "좌석 정보", example = "A열 3번")
-        String seatNumber
+        String seatNumber,
+
+        @Schema(description = "시작 일자")
+        Instant startDate,
+
+        @Schema(description = "종료 일자")
+        Instant endDate
 )  {
-    public static TicketEventResponseDto from(Event event, Long performanceId) {
+    public static TicketEventResponseDto from(Event event, Performance performance) {
         String seatNumber = event.getSeat().getSeatNumber(); // ex: "A45"
         String row = seatNumber.replaceAll("[0-9]", "");
         String number = seatNumber.replaceAll("[^0-9]", "");
         String ticketSeat = row + "열 " + number + "번";
 
+
         return new TicketEventResponseDto(
                 event.getId(),
-                performanceId,
+                performance.getId(),
                 event.getName(),
-                ticketSeat
+                ticketSeat,
+                performance.getStartDate(),
+                performance.getEndDate()
         );
     }
 }

--- a/src/main/java/com/profect/tickle/domain/event/dto/response/TicketListResponseDto.java
+++ b/src/main/java/com/profect/tickle/domain/event/dto/response/TicketListResponseDto.java
@@ -1,15 +1,20 @@
 package com.profect.tickle.domain.event.dto.response;
 
+import java.time.Instant;
+
 public record TicketListResponseDto(
-        Long id,
+        Long eventId,
         String name,
         Short perPrice,
-        String img
+        String img,
+        Long statusId,
+        Instant startDate,
+        Instant endDate
 ) implements EventListResponseDto {
 
     @Override
     public Long getEventId() {
-        return id;
+        return eventId;
     }
 
     @Override

--- a/src/main/java/com/profect/tickle/domain/event/entity/Coupon.java
+++ b/src/main/java/com/profect/tickle/domain/event/entity/Coupon.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +28,7 @@ public class Coupon {
     @Column(name = "coupon_name", length = 10, nullable = false)
     private String name;
 
-    @Column(name = "coupon_content", length = 10, nullable = false)
+    @Column(name = "coupon_content", length = 20, nullable = false)
     private String content;
 
     @Column(name = "coupon_count", nullable = false)
@@ -39,7 +38,7 @@ public class Coupon {
     private Short rate;
 
     @Column(name = "coupon_valid", nullable = false)
-    private LocalDate valid;
+    private Instant valid;
 
     @Column(name = "coupon_created_at", nullable = false)
     private Instant createdAt;
@@ -61,7 +60,7 @@ public class Coupon {
         this.updatedAt = Instant.now();
     }
 
-    private Coupon(String name, String content, Short count, Short rate, LocalDate valid) {
+    private Coupon(String name, String content, Short count, Short rate, Instant valid) {
         this.name = name;
         this.content = content;
         this.count = count;
@@ -69,7 +68,7 @@ public class Coupon {
         this.valid = valid;
     }
 
-    public static Coupon create(String name, String content, Short count, Short rate, LocalDate valid) {
+    public static Coupon create(String name, String content, Short count, Short rate, Instant valid) {
         return new Coupon(name, content, count, rate, valid);
     }
 

--- a/src/main/java/com/profect/tickle/domain/event/entity/Event.java
+++ b/src/main/java/com/profect/tickle/domain/event/entity/Event.java
@@ -1,7 +1,6 @@
 package com.profect.tickle.domain.event.entity;
 
 import com.profect.tickle.domain.event.dto.request.TicketEventCreateRequestDto;
-import com.profect.tickle.domain.performance.entity.Performance;
 import com.profect.tickle.domain.reservation.entity.Seat;
 import com.profect.tickle.global.exception.BusinessException;
 import com.profect.tickle.global.exception.ErrorCode;
@@ -12,7 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 
 @Getter
 @Entity

--- a/src/main/java/com/profect/tickle/domain/event/mapper/CouponMapper.java
+++ b/src/main/java/com/profect/tickle/domain/event/mapper/CouponMapper.java
@@ -1,5 +1,6 @@
 package com.profect.tickle.domain.event.mapper;
 
+import com.profect.tickle.domain.event.dto.response.CouponListResponseDto;
 import com.profect.tickle.domain.event.dto.response.ExpiringSoonCouponResponseDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -10,4 +11,5 @@ import java.util.List;
 @Mapper
 public interface CouponMapper {
     List<ExpiringSoonCouponResponseDto> findCouponsExpiringBefore(@Param("targetDate") Instant targetDate);
+    CouponListResponseDto findCouponById(@Param("couponId") Long couponId);
 }

--- a/src/main/java/com/profect/tickle/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/profect/tickle/domain/event/mapper/EventMapper.java
@@ -10,6 +10,7 @@ import java.util.List;
 public interface EventMapper {
     List<TicketListResponseDto> findTicketEventList(@Param("size") int size, @Param("offset") int offset);
     List<CouponListResponseDto> findCouponEventList(@Param("size") int size, @Param("offset") int offset);
+
     TicketEventDetailResponseDto findTicketEventDetail(@Param("eventId") Long eventId);
     List<TicketListResponseDto> searchTicketEvents(@Param("keyword") String keyword, @Param("size") int size, @Param("offset") int offset);
     List<SeatProjection> findRandomOngoingEvents(int size, int offset);

--- a/src/main/java/com/profect/tickle/domain/event/service/CouponService.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/CouponService.java
@@ -51,8 +51,6 @@ public class CouponService {
     }
 
     public CouponListResponseDto getSpecialCouponDetailById(Long couponId) {
-        if (!List.of(1L, 2L, 3L).contains(couponId)) throw new BusinessException(ErrorCode.COUPON_NOT_FOUND);
-
         CouponListResponseDto dto = couponMapper.findCouponById(couponId);
         if (dto == null) throw new BusinessException(ErrorCode.COUPON_NOT_FOUND);
 

--- a/src/main/java/com/profect/tickle/domain/event/service/CouponService.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/CouponService.java
@@ -1,9 +1,15 @@
 package com.profect.tickle.domain.event.service;
 
+import com.profect.tickle.domain.event.dto.response.CouponListResponseDto;
 import com.profect.tickle.domain.event.dto.response.CouponResponseDto;
+import com.profect.tickle.domain.event.entity.Coupon;
+import com.profect.tickle.domain.event.mapper.CouponMapper;
 import com.profect.tickle.domain.event.mapper.CouponReceivedMapper;
+import com.profect.tickle.domain.event.repository.CouponRepository;
 import com.profect.tickle.domain.member.entity.CouponReceived;
 import com.profect.tickle.domain.member.repository.CouponReceivedRepository;
+import com.profect.tickle.global.exception.BusinessException;
+import com.profect.tickle.global.exception.ErrorCode;
 import com.profect.tickle.global.status.Status;
 import com.profect.tickle.global.status.repository.StatusRepository;
 import java.util.List;
@@ -19,6 +25,7 @@ public class CouponService {
     private static final Long USED_COUPON_STATUS_ID = 18L;
 
     private final CouponReceivedMapper couponReceivedMapper;
+    private final CouponMapper couponMapper;
     private final CouponReceivedRepository couponReceivedRepository;
     private final StatusRepository statusRepository;
 
@@ -41,6 +48,15 @@ public class CouponService {
         CouponReceived couponReceived = findValidCoupon(couponId, memberId);
 
         return calculateDiscountAmount(totalAmount, couponReceived.getCoupon().getRate());
+    }
+
+    public CouponListResponseDto getSpecialCouponDetailById(Long couponId) {
+        if (!List.of(1L, 2L, 3L).contains(couponId)) throw new BusinessException(ErrorCode.COUPON_NOT_FOUND);
+
+        CouponListResponseDto dto = couponMapper.findCouponById(couponId);
+        if (dto == null) throw new BusinessException(ErrorCode.COUPON_NOT_FOUND);
+
+        return dto;
     }
 
     private CouponReceived findValidCoupon(Long couponId, Long memberId) {

--- a/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
@@ -37,6 +37,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
@@ -34,7 +34,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
@@ -16,6 +16,9 @@ import com.profect.tickle.domain.member.entity.CouponReceived;
 import com.profect.tickle.domain.member.entity.Member;
 import com.profect.tickle.domain.member.repository.CouponReceivedRepository;
 import com.profect.tickle.domain.member.repository.MemberRepository;
+import com.profect.tickle.domain.performance.entity.Performance;
+import com.profect.tickle.domain.performance.repository.PerformanceRepository;
+import com.profect.tickle.domain.performance.service.PerformanceService;
 import com.profect.tickle.domain.point.entity.Point;
 import com.profect.tickle.domain.point.entity.PointTarget;
 import com.profect.tickle.domain.point.repository.PointRepository;
@@ -56,6 +59,8 @@ public class EventServiceImpl implements EventService {
     private final CouponReceivedMapper couponReceivedMapper;
 
     private final PointTarget eventTarget = PointTarget.EVENT;
+    private final PerformanceService performanceService;
+    private final PerformanceRepository performanceRepository;
 
     @Override
     @Transactional
@@ -67,7 +72,7 @@ public class EventServiceImpl implements EventService {
                 request.content(),
                 request.count(),
                 request.rate(),
-                request.valid()
+                request.validDate()
         );
         couponRepository.save(coupon);
 
@@ -86,10 +91,12 @@ public class EventServiceImpl implements EventService {
         Status status = getStatusOrThrow(4L);
         Seat seat = getSeatOrThrow(request.seatId());
         Event ticketEvent = Event.create(status, seat, request);
+        Performance performance = getPerformanceOrThrow(request);
 
         eventRepository.save(ticketEvent);
+        seat.assignEvent(ticketEvent);
 
-        return TicketEventResponseDto.from(ticketEvent, request.performanceId());
+        return TicketEventResponseDto.from(ticketEvent, performance);
     }
 
     @Override
@@ -205,7 +212,9 @@ public class EventServiceImpl implements EventService {
                             r.eventId(),
                             r.performanceId(),
                             r.eventName(),
-                            formattedSeat
+                            formattedSeat,
+                            r.startDate(),
+                            r.endDate()
                     );
                 })
                 .toList();
@@ -244,6 +253,11 @@ public class EventServiceImpl implements EventService {
         Long memberId = SecurityUtil.getSignInMemberId();
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Performance getPerformanceOrThrow(TicketEventCreateRequestDto request) {
+        return performanceRepository.findById(request.performanceId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PERFORMANCE_NOT_FOUND));
     }
 
     public List<ExpiringSoonCouponResponseDto> getCouponsExpiringWithinOneDay() {

--- a/src/main/java/com/profect/tickle/domain/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/profect/tickle/domain/member/dto/response/MemberResponseDto.java
@@ -7,8 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Getter
 @Builder

--- a/src/main/java/com/profect/tickle/domain/performance/dto/request/PerformanceRequestDto.java
+++ b/src/main/java/com/profect/tickle/domain/performance/dto/request/PerformanceRequestDto.java
@@ -2,15 +2,9 @@ package com.profect.tickle.domain.performance.dto.request;
 
 import com.profect.tickle.domain.performance.entity.HallType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 
 @Getter
 @Schema(description = "공연생성 요청 DTO")

--- a/src/main/java/com/profect/tickle/domain/performance/dto/request/UpdatePerformanceRequestDto.java
+++ b/src/main/java/com/profect/tickle/domain/performance/dto/request/UpdatePerformanceRequestDto.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/profect/tickle/domain/performance/dto/response/PerformanceResponseDto.java
+++ b/src/main/java/com/profect/tickle/domain/performance/dto/response/PerformanceResponseDto.java
@@ -7,8 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/profect/tickle/domain/performance/entity/Performance.java
+++ b/src/main/java/com/profect/tickle/domain/performance/entity/Performance.java
@@ -8,7 +8,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 
 @Getter
 @Entity

--- a/src/main/java/com/profect/tickle/domain/performance/entity/PerformanceFavorite.java
+++ b/src/main/java/com/profect/tickle/domain/performance/entity/PerformanceFavorite.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 
 @Getter
 @Entity

--- a/src/main/java/com/profect/tickle/domain/performance/service/KopisPerformanceImporterService.java
+++ b/src/main/java/com/profect/tickle/domain/performance/service/KopisPerformanceImporterService.java
@@ -3,9 +3,14 @@ package com.profect.tickle.domain.performance.service;
 import com.profect.tickle.domain.member.entity.Member;
 import com.profect.tickle.domain.member.repository.MemberRepository;
 import com.profect.tickle.domain.performance.dto.KopisPerformanceDto;
-import com.profect.tickle.domain.performance.entity.*;
+import com.profect.tickle.domain.performance.entity.Genre;
+import com.profect.tickle.domain.performance.entity.Hall;
+import com.profect.tickle.domain.performance.entity.HallType;
+import com.profect.tickle.domain.performance.entity.Performance;
 import com.profect.tickle.domain.performance.parser.KopisXmlParser;
-import com.profect.tickle.domain.performance.repository.*;
+import com.profect.tickle.domain.performance.repository.GenreRepository;
+import com.profect.tickle.domain.performance.repository.HallRepository;
+import com.profect.tickle.domain.performance.repository.PerformanceRepository;
 import com.profect.tickle.domain.reservation.repository.SeatTemplateRepository;
 import com.profect.tickle.global.status.Status;
 import com.profect.tickle.global.status.repository.StatusRepository;
@@ -20,7 +25,10 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
-import java.time.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 

--- a/src/main/java/com/profect/tickle/domain/reservation/entity/Seat.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/entity/Seat.java
@@ -74,6 +74,8 @@ public class Seat {
         this.member = member;
     }
 
+    public void assignEvent(Event event) {this.event = event;}
+
     public void assignReservation(Reservation reservation) {
         this.reservation = reservation;
     }

--- a/src/main/resources/mapper/event/CouponMapper.xml
+++ b/src/main/resources/mapper/event/CouponMapper.xml
@@ -5,6 +5,17 @@
 
 <mapper namespace="com.profect.tickle.domain.event.mapper.CouponMapper">
 
+    <resultMap id="CouponListMap" type="com.profect.tickle.domain.event.dto.response.CouponListResponseDto">
+        <constructor>
+            <arg column="id" javaType="java.lang.Long"/>
+            <arg column="name" javaType="java.lang.String"/>
+            <arg column="rate" javaType="short"/>
+            <arg column="eventId" javaType="java.lang.Long"/>
+            <arg column="validDate" javaType="java.time.Instant"/>
+        </constructor>
+    </resultMap>
+
+
     <!-- 만료일이 targetDate 이전인 쿠폰 조회 -->
     <select id="findCouponsExpiringBefore" parameterType="java.time.Instant" resultType="ExpiringSoonCouponResponseDto">
         SELECT
@@ -19,15 +30,17 @@
         WHERE coupon.coupon_valid &lt;= #{targetDate}
     </select>
 
-    <select id="findCouponById" resultType="com.profect.tickle.domain.event.dto.response.CouponListResponseDto">
+    <select id="findCouponById" resultMap="CouponListMap">
         SELECT
             c.coupon_id AS id,
             c.coupon_name AS name,
             c.coupon_rate AS rate,
-            e.event_id AS eventId
+            e.event_id AS eventId,
+            c.coupon_valid AS validDate
         FROM coupon c
                  JOIN event e ON c.coupon_id = e.coupon_id
         WHERE c.coupon_id = #{couponId}
+            AND c.coupon_valid >= NOW()
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/event/CouponMapper.xml
+++ b/src/main/resources/mapper/event/CouponMapper.xml
@@ -19,4 +19,15 @@
         WHERE coupon.coupon_valid &lt;= #{targetDate}
     </select>
 
+    <select id="findCouponById" resultType="com.profect.tickle.domain.event.dto.response.CouponListResponseDto">
+        SELECT
+            c.coupon_id AS id,
+            c.coupon_name AS name,
+            c.coupon_rate AS rate,
+            e.event_id AS eventId
+        FROM coupon c
+                 JOIN event e ON c.coupon_id = e.coupon_id
+        WHERE c.coupon_id = #{couponId}
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/event/EventMapper.xml
+++ b/src/main/resources/mapper/event/EventMapper.xml
@@ -5,27 +5,56 @@
 
 <mapper namespace="com.profect.tickle.domain.event.mapper.EventMapper">
 
-    <select id="findCouponEventList" resultType="com.profect.tickle.domain.event.dto.response.CouponListResponseDto">
+    <resultMap id="CouponListMap" type="com.profect.tickle.domain.event.dto.response.CouponListResponseDto">
+        <constructor>
+            <arg column="id" javaType="java.lang.Long"/>
+            <arg column="name" javaType="java.lang.String"/>
+            <arg column="rate" javaType="short"/>
+            <arg column="eventId" javaType="java.lang.Long"/>
+            <arg column="validDate" javaType="java.time.Instant"/>
+        </constructor>
+    </resultMap>
+    <resultMap id="TicketListMap" type="com.profect.tickle.domain.event.dto.response.TicketListResponseDto">
+        <constructor>
+            <arg column="id" javaType="java.lang.Long"/>
+            <arg column="name" javaType="java.lang.String"/>
+            <arg column="perPrice" javaType="short"/>
+            <arg column="img" javaType="java.lang.String"/>
+            <arg column="statusId" javaType="java.lang.Long"/>
+            <arg column="startDate" javaType="java.time.Instant"/>
+            <arg column="endDate" javaType="java.time.Instant"/>
+        </constructor>
+    </resultMap>
+
+    <select id="findCouponEventList" resultMap="CouponListMap">
         SELECT
             c.coupon_id AS id,
             c.coupon_name AS name,
-            c.coupon_rate AS rate
+            c.coupon_rate AS rate,
+            e.event_id AS eventId,
+            c.coupon_valid AS validDate
         FROM coupon c
+            JOIN event e ON c.coupon_id = e.coupon_id
+        WHERE c.coupon_valid >= NOW()
         ORDER BY c.coupon_created_at DESC
             LIMIT #{size} OFFSET #{offset}
     </select>
 
-    <select id="findTicketEventList" resultType="com.profect.tickle.domain.event.dto.response.TicketListResponseDto">
+    <select id="findTicketEventList" resultMap="TicketListMap">
         SELECT
         e.event_id AS id,
         e.event_name AS name,
         e.event_per_price AS perPrice,
-        p.performance_img AS img
+        p.performance_img AS img,
+        st.status_id AS statusId,
+        p.performance_start_date AS startDate,
+        p.performance_end_date AS endDate
         FROM event e
         JOIN seat s ON e.seat_id = s.seat_id
         JOIN performance p ON s.performance_id = p.performance_id
         JOIN status st ON e.status_id = st.status_id
-        WHERE st.status_code IN (100, 101)  <!-- 예정, 진행 -->
+        WHERE p.performance_start_date &lt;= NOW()
+          AND p.performance_end_date &gt;= NOW()
         ORDER BY e.event_created_at DESC
         LIMIT #{size} OFFSET #{offset}
     </select>
@@ -38,16 +67,19 @@
             FROM event e
                      JOIN status s ON e.status_id = s.status_id
             WHERE e.coupon_id = c.coupon_id
-              AND s.status_code IN (100, 101)
+            AND c.coupon_valid >= NOW()
         )
     </select>
 
     <select id="countTicketEvents" resultType="int">
         SELECT COUNT(*)
         FROM event e
-                 JOIN status s ON e.status_id = s.status_id
+        JOIN status s ON e.status_id = s.status_id
+        JOIN seat se ON e.seat_id = se.seat_id
+        JOIN performance p ON se.performance_id = p.performance_id
         WHERE e.event_type = 1
-          AND s.status_code IN (100, 101)
+          AND p.performance_start_date &lt;= NOW()
+          AND p.performance_end_date &gt;= NOW()
     </select>
 
     <select id="findTicketEventDetail"
@@ -71,21 +103,25 @@
         WHERE e.event_id = #{eventId}
     </select>
 
-    <select id="searchTicketEvents" resultType="com.profect.tickle.domain.event.dto.response.TicketListResponseDto">
+    <select id="searchTicketEvents" resultMap="TicketListMap">
         SELECT
-            e.event_id AS id,
-            e.event_name AS name,
-            e.event_per_price AS perPrice,
-            p.performance_img AS img
+        e.event_id AS id,
+        e.event_name AS name,
+        e.event_per_price AS perPrice,
+        p.performance_img AS img,
+        st.status_id AS statusId,
+        p.performance_start_date AS startDate,
+        p.performance_end_date AS endDate
         FROM event e
-                 JOIN seat s ON e.seat_id = s.seat_id
-                 JOIN performance p ON s.performance_id = p.performance_id
-                 JOIN status st ON e.status_id = st.status_id
+        JOIN seat s ON e.seat_id = s.seat_id
+        JOIN performance p ON s.performance_id = p.performance_id
+        JOIN status st ON e.status_id = st.status_id
         WHERE e.event_type = 1
-          AND st.status_code IN (100, 101)
-          AND e.event_name LIKE '%' || #{keyword} || '%'
+        AND e.event_name LIKE '%' || #{keyword} || '%'
+        AND p.performance_start_date &lt;= NOW()
+          AND p.performance_end_date &gt;= NOW()
         ORDER BY e.event_created_at DESC
-            LIMIT #{size}
+        LIMIT #{size}
         OFFSET #{offset}
     </select>
 
@@ -94,7 +130,7 @@
         FROM event e
                  JOIN status s ON e.status_id = s.status_id
         WHERE e.event_type = 1
-          AND s.status_code IN (100, 101)
+          AND e.status_id IN (4, 5)
           AND e.event_name LIKE '%' || #{keyword} || '%'
     </select>
 
@@ -104,12 +140,16 @@
             e.event_id AS eventId,
             p.performance_id AS performanceId,
             e.event_name AS eventName,
-            s.seat_number AS seatNumber
+            s.seat_number AS seatNumber,
+            p.performance_start_date AS startDate,
+            p.performance_end_date AS endDate
         FROM event e
                  JOIN status st ON e.status_id = st.status_id
                  JOIN seat s ON e.seat_id = s.seat_id
                  JOIN performance p ON s.performance_id = p.performance_id
         WHERE st.status_id IN (4, 5)
+          AND p.performance_start_date &lt;= NOW()
+          AND p.performance_end_date &gt;= NOW()
         ORDER BY RANDOM()
             LIMIT #{size} OFFSET #{offset}
     </select>


### PR DESCRIPTION
## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 
- #78 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

### 1. 쿠폰 단일조회 API를 추가하였습니다.
이벤트 홈페이지에서, 고정적으로 발급할 수 있는 쿠폰을 보여주기 위해 API를 개발하였습니다.

### 2. LocalDate 타입 -> Instant로 통일
이벤트에 시간 관련된 필드의 데이터 타입을 Instant로 통일하였습니다. 



## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
