### PR TITLE
feat: 건별~월간 조건에 맞게 정산 상태 업데이트(스케줄러)

### DIFF
--- a/src/main/java/com/profect/tickle/domain/settlement/mapper/SettlementDailyMapper.java
+++ b/src/main/java/com/profect/tickle/domain/settlement/mapper/SettlementDailyMapper.java
@@ -2,9 +2,11 @@ package com.profect.tickle.domain.settlement.mapper;
 
 import com.profect.tickle.domain.settlement.dto.batch.SettlementDailyFindTargetDto;
 import com.profect.tickle.domain.settlement.entity.SettlementDaily;
+import com.profect.tickle.global.status.Status;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.time.Instant;
 import java.util.List;
 
 @Mapper
@@ -19,5 +21,13 @@ public interface SettlementDailyMapper {
      * 일간정산 테이블 insert + update
      */
     void upsertSettlementDaily(@Param("list") List<SettlementDaily> list);
+
+    /**
+     * 1) 일간정산 상태 업데이트(예매 종료일시 기준)
+     * 2) 일간정산 상태 업데이트(월요일 또는 1일 기준)
+     */
+    void updateSettlementDailyStatus(@Param("beforeStatus") Status beforeStatus,
+                                     @Param("afterStatus") Status afterStatus,
+                                     @Param("endOfDay") Instant endOfDay);
 
 }

--- a/src/main/java/com/profect/tickle/domain/settlement/mapper/SettlementDetailMapper.java
+++ b/src/main/java/com/profect/tickle/domain/settlement/mapper/SettlementDetailMapper.java
@@ -2,9 +2,11 @@ package com.profect.tickle.domain.settlement.mapper;
 
 import com.profect.tickle.domain.settlement.dto.batch.SettlementDetailFindTargetDto;
 import com.profect.tickle.domain.settlement.entity.SettlementDetail;
+import com.profect.tickle.global.status.Status;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.time.Instant;
 import java.util.List;
 
 @Mapper
@@ -19,4 +21,11 @@ public interface SettlementDetailMapper {
      * 건별정산에 결과 insert
      */
     void insertSettlementDetail(@Param("list") List<SettlementDetail> list);
+
+    /**
+     * 건별 정산 상태 업데이트
+     */
+    void updateSettlementDetailStatus(@Param("beforeStatus") Status beforeStatus,
+                                      @Param("afterStatus") Status afterStatus,
+                                      @Param("endOfDay") Instant endOfDay);
 }

--- a/src/main/java/com/profect/tickle/domain/settlement/mapper/SettlementMonthlyMapper.java
+++ b/src/main/java/com/profect/tickle/domain/settlement/mapper/SettlementMonthlyMapper.java
@@ -2,7 +2,9 @@ package com.profect.tickle.domain.settlement.mapper;
 
 import com.profect.tickle.domain.settlement.dto.batch.SettlementMonthlyFindTargetDto;
 import com.profect.tickle.domain.settlement.entity.SettlementMonthly;
+import com.profect.tickle.global.status.Status;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.HashMap;
 import java.util.List;
@@ -20,4 +22,11 @@ public interface SettlementMonthlyMapper {
      */
     void upsertSettlementMonthly(List<SettlementMonthly> list);
 
+    /**
+     * 1일 기준 지난 달 정산 상태 업데이트
+     */
+    void updateSettlementMonthlyStatus(@Param("beforeStatus") Status beforeStatus,
+                                       @Param("afterStatus") Status afterStatus,
+                                       @Param("year") String year,
+                                       @Param("month") String month);
 }

--- a/src/main/java/com/profect/tickle/domain/settlement/mapper/SettlementWeeklyMapper.java
+++ b/src/main/java/com/profect/tickle/domain/settlement/mapper/SettlementWeeklyMapper.java
@@ -2,6 +2,7 @@ package com.profect.tickle.domain.settlement.mapper;
 
 import com.profect.tickle.domain.settlement.dto.batch.SettlementWeeklyFindTargetDto;
 import com.profect.tickle.domain.settlement.entity.SettlementWeekly;
+import com.profect.tickle.global.status.Status;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -20,4 +21,13 @@ public interface SettlementWeeklyMapper {
      * 추출한 일간정산 데이터 연, 월, 주차, 상호명, 공연 유니크로 upsert
      */
     void upsertSettlementWeekly(@Param("list") List<SettlementWeekly> list);
+
+    /**
+     * 월요일 또는 1일 기준 n-1회차 정산 상태 업데이트
+     */
+    void updateSettlementDetailStatus(@Param("beforeStatus") Status beforeStatus,
+                                      @Param("afterStatus") Status afterStatus,
+                                      @Param("year") String year,
+                                      @Param("month") String month,
+                                      @Param("week") String week);
 }

--- a/src/main/java/com/profect/tickle/domain/settlement/service/SettlementStatusScheduler.java
+++ b/src/main/java/com/profect/tickle/domain/settlement/service/SettlementStatusScheduler.java
@@ -1,0 +1,29 @@
+package com.profect.tickle.domain.settlement.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SettlementStatusScheduler {
+
+    private final SettlementDetailService settlementDetailService;
+    private final SettlementDailyService settlementDailyService;
+    private final SettlementWeeklyService settlementWeeklyService;
+    private final SettlementMonthlyService settlementMonthlyService;
+
+    /**
+     * 매일 00시00분01초에 건별, 일별, 주간, 월간 정산 상태 업데이트
+     */
+    @Scheduled(cron = "1 0 0 * * *")
+    public void updateSettlementStatus() {
+        settlementDetailService.updateDetail(); // 건별 업데이트
+        settlementDailyService.updateDailyByToday(); // 일별 업데이트(예매 종료일시 기준)
+        settlementDailyService.updateDailyByBoundary(); // 일별 업데이트(월요일 또는 1일 기준)
+        settlementWeeklyService.updateWeekly(); // 주간 업데이트(월요일 또는 1일 기준)
+        settlementMonthlyService.updateMonthly(); // 월간 업데이트(1일 기준)
+    }
+}

--- a/src/main/resources/mapper/settlement/SettlementDailyMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementDailyMapper.xml
@@ -97,4 +97,14 @@
             -- 수정 날짜 = 받은 날짜
             settlement_daily_updated_at = EXCLUDED.settlement_daily_created_at
     </insert>
+
+    <!-- 1) 예매 종료일시 <= n일23시59분59초.999 && '정산예정'
+         2) 오늘이 월요일 또는 1일인 경우, 이전 건들 업데이트 -->
+    <update id="updateSettlementDailyStatus">
+        UPDATE settlement_daily
+        SET status_id = #{afterStatus.id}
+        WHERE performance_end_date &lt;= #{endOfDay}
+        AND status_id = #{beforeStatus.id}
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/settlement/SettlementDetailMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementDetailMapper.xml
@@ -77,4 +77,12 @@
         )
         </foreach>
     </insert>
+
+    <!-- 예매종료일시가 n일23시59분59초.999 이하 && 정산상태가 '정산완료'인 건들 업데이트 -->
+    <update id="updateSettlementDetailStatus">
+        UPDATE settlement_detail
+        SET status_id = #{afterStatus.id}
+        WHERE performance_end_date &lt;= #{endOfDay}
+        AND status_id = #{beforeStatus.id}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/settlement/SettlementMonthlyMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMonthlyMapper.xml
@@ -4,9 +4,7 @@
 
 <mapper namespace="com.profect.tickle.domain.settlement.mapper.SettlementMonthlyMapper">
 
-    <!--
-    * 주간정산 집계하여 월간정산
-    -->
+    <!-- 주간정산 집계하여 월간정산 -->
     <select id="findByWeek" parameterType="map"
             resultType="com.profect.tickle.domain.settlement.dto.batch.SettlementMonthlyFindTargetDto">
         SELECT
@@ -63,4 +61,13 @@
             settlement_monthly_net_amount = EXCLUDED.settlement_monthly_net_amount,
             settlement_monthly_updated_at = EXCLUDED.settlement_monthly_created_at
     </insert>
+
+    <!-- 1일 기준 이전 달의 정산 상태 업데이트 -->
+    <update id="updateSettlementMonthlyStatus">
+        UPDATE settlement_monthly
+        SET status_id = #{afterStatus.id}
+        WHERE settlement_year = #{year}
+        AND settlement_month = #{month}
+        AND status_id = #{beforeStatus.id}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/settlement/SettlementWeeklyMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementWeeklyMapper.xml
@@ -65,4 +65,14 @@
             settlement_weekly_net_amount = EXCLUDED.settlement_weekly_net_amount,
             settlement_weekly_updated_at = EXCLUDED.settlement_weekly_created_at
     </insert>
+
+    <!-- 월요일 또는 1일인 경우 n-1회차의 정산예정 건들 업데이트-->
+    <update id="updateSettlementDetailStatus">
+        UPDATE settlement_weekly
+        SET status_id = #{afterStatus.id}
+        WHERE settlement_year = #{year}
+        AND settlement_month = #{month}
+        AND settlement_week = #{week}
+        AND status_id = #{beforeStatus.id}
+    </update>
 </mapper>


### PR DESCRIPTION
## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 
- #95 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

정산 상태 업데이트(스케줄러: 매일 00시00분01초)
1) 건별: '예매 종료일시 <= n일 23시59분59초 999' && '정산예정'에 부합하는 건들 '정산완료'로 업데이트
2) 일별:
    2-1) '예매 종료일시 <= n일 23시59분59초 999' && '정산예정'에 부합하는 건들 '정산완료'로 업데이트
    2-2) 기준일이 월요일 또는 1일이면 '예매 종료일시 <= n일 23시59분59초 999' && '정산예정'에 부합하는 건들 '정산완료'로 업데이트
3) 주간: 기준일이 월요일 또는 1일이면 'n-1'주차 && '정산예정'에 부합하는 건들 '정산완료'로 업데이트
4) 월간: 기준일이 1일이면 'n-1'월 && '정산예정'에 부합하는 건들 '정산완료로 업데이트

## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
