### PR TITLE
fix: 이벤트 목표금액을 초과 시, 이벤트가 종료되지 않는 에러

### DIFF
--- a/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
@@ -111,7 +111,7 @@ public class EventServiceImpl implements EventService {
 
         event.accumulate(event.getPerPrice());
 
-        boolean isWinner = (event.getAccrued().equals(event.getGoalPrice()));
+        boolean isWinner = (event.getAccrued() >= event.getGoalPrice());
         if (isWinner) {
             Seat seat = getSeatOrThrow(event.getSeat().getId());
             event.updateStatus(getStatusOrThrow(6L));
@@ -121,7 +121,7 @@ public class EventServiceImpl implements EventService {
                     member,
                     seat.getPerformance(),
                     getStatusOrThrow(9L),
-                    event.getGoalPrice()
+                    event.getAccrued()
             );
 
             reservation.assignSeat(seat);


### PR DESCRIPTION
## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 
- #114 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

이벤트 목표금액과 누적금액이 일치하면 이벤트가 종료되지만, 이벤트 누적금액이 목표금액을 초과할 시 이벤트가 종료되지않고 계속 누적금액이 쌓이는 에러를 해결하였습니다.

이벤트 당첨 시, 목표금액을 초과해도 이벤트가 종료됨
<img width="1443" height="757" alt="스크린샷 2025-08-11 오후 3 04 50" src="https://github.com/user-attachments/assets/913bf755-f007-4a89-82f2-e0c11354417d" />

[누적금액 / 목표금액]
<img width="354" height="40" alt="스크린샷 2025-08-11 오후 2 50 22" src="https://github.com/user-attachments/assets/d87af6ab-b3b2-4791-b576-334bace45f87" />


<img width="1491" height="470" alt="스크린샷 2025-08-11 오후 3 05 01" src="https://github.com/user-attachments/assets/7e495ad1-fb78-4478-9af7-a7cdb6e45982" />



## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
