### PR TITLE
feat: 이벤트 스케쥴러 구현

### DIFF
--- a/src/main/java/com/profect/tickle/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/profect/tickle/domain/event/mapper/EventMapper.java
@@ -18,4 +18,8 @@ public interface EventMapper {
     int countSearchTicketEvents(@Param("keyword") String keyword);
     long countCouponEvents(); // 페이징처리 시, 전체 쿠폰의 갯수를 알기 위한 메서드
     Integer countTicketEvents(); // 페이징처리 시, 전체 티켓의 갯수를 알기 위한 메서드
+
+    // 스케쥴러 update mapper 추가
+    int markEventsAsOngoing();  // 변경된 행 수 리턴
+    int markEventsAsFinished();
 }

--- a/src/main/java/com/profect/tickle/domain/event/scheduler/EventStatusScheduler.java
+++ b/src/main/java/com/profect/tickle/domain/event/scheduler/EventStatusScheduler.java
@@ -1,0 +1,23 @@
+package com.profect.tickle.domain.event.scheduler;
+
+import com.profect.tickle.domain.event.mapper.EventMapper;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EventStatusScheduler {
+
+    private final EventMapper eventMapper;
+
+    @Scheduled(cron = "0 * * * * *") // 매 분 0초
+    @Transactional
+    public void syncEventStatuses() {
+        int toOngoing = eventMapper.markEventsAsOngoing();
+        int toFinished = eventMapper.markEventsAsFinished();
+        // 필요하면 로그
+        // log.info("event status updated: toOngoing={}, toFinished={}", toOngoing, toFinished);
+    }
+}

--- a/src/main/resources/mapper/event/EventMapper.xml
+++ b/src/main/resources/mapper/event/EventMapper.xml
@@ -153,4 +153,28 @@
         ORDER BY RANDOM()
             LIMIT #{size} OFFSET #{offset}
     </select>
+    <!-- 진행 전 -> 진행 중 -->
+    <update id="markEventsAsOngoing">
+        UPDATE event e
+        SET status_id = 5,
+            event_updated_at = NOW()
+        FROM seat s
+        JOIN performance p ON s.performance_id = p.performance_id
+        WHERE e.seat_id = s.seat_id
+          AND e.status_id = 4
+          AND p.performance_start_date &lt;= NOW()
+          AND p.performance_end_date &gt; NOW()
+    </update>
+
+    <!-- 진행 전/중 -> 종료 -->
+    <update id="markEventsAsFinished">
+        UPDATE event e
+        SET status_id = 6,
+            event_updated_at = NOW()
+        FROM seat s
+        JOIN performance p ON s.performance_id = p.performance_id
+        WHERE e.seat_id = s.seat_id
+          AND e.status_id IN (4, 5)
+          AND p.performance_end_date &lt;= NOW()
+    </update>
 </mapper>

--- a/src/main/resources/mapper/event/EventMapper.xml
+++ b/src/main/resources/mapper/event/EventMapper.xml
@@ -53,8 +53,7 @@
         JOIN seat s ON e.seat_id = s.seat_id
         JOIN performance p ON s.performance_id = p.performance_id
         JOIN status st ON e.status_id = st.status_id
-        WHERE p.performance_start_date &lt;= NOW()
-          AND p.performance_end_date &gt;= NOW()
+        WHERE p.performance_end_date &gt;= NOW()
         ORDER BY e.event_created_at DESC
         LIMIT #{size} OFFSET #{offset}
     </select>
@@ -118,8 +117,7 @@
         JOIN status st ON e.status_id = st.status_id
         WHERE e.event_type = 1
         AND e.event_name LIKE '%' || #{keyword} || '%'
-        AND p.performance_start_date &lt;= NOW()
-          AND p.performance_end_date &gt;= NOW()
+        AND p.performance_end_date &gt;= NOW()
         ORDER BY e.event_created_at DESC
         LIMIT #{size}
         OFFSET #{offset}
@@ -153,6 +151,7 @@
         ORDER BY RANDOM()
             LIMIT #{size} OFFSET #{offset}
     </select>
+
     <!-- 진행 전 -> 진행 중 -->
     <update id="markEventsAsOngoing">
         UPDATE event e


### PR DESCRIPTION
## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 
- #116 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

이벤트 스케쥴러를 구현하였습니다.
- 공연 예매 시작 시, 이벤트가 같이 상태코드가 5L로 변경되며 진행중 상태로 변경되도록 구현
- 공연 예매 종료 시, 이벤트가 같이 상태코드가 6L로 변경되며 진행중인 이벤트에서 사라지도록 구현
- 공연 예매 종료 전, 이벤트 목표금액 도달 시, 상태코드가 6L로 변경되며 진행중인 이벤트에서 종료된 이벤트로 상태 변경

이벤트 매퍼 수정
- 공연 예매 시작 시 동시에 이벤트 리스트에 도출되는 것이 아닌, 이벤트 생성 시 이벤트 리스트에 진행 전으로 도출되도록 변경

## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
