### PR TITLE
bug: 예매 성공 시 알림 미발송 오류 수정

### DIFF
--- a/src/main/java/com/profect/tickle/domain/notification/scheduler/CouponScheduler.java
+++ b/src/main/java/com/profect/tickle/domain/notification/scheduler/CouponScheduler.java
@@ -1,4 +1,4 @@
-package com.profect.tickle.domain.event.scheduler;
+package com.profect.tickle.domain.notification.scheduler;
 
 import com.profect.tickle.domain.event.dto.response.ExpiringSoonCouponResponseDto;
 import com.profect.tickle.domain.event.service.EventService;

--- a/src/main/java/com/profect/tickle/domain/notification/scheduler/EventStatusScheduler.java
+++ b/src/main/java/com/profect/tickle/domain/notification/scheduler/EventStatusScheduler.java
@@ -1,4 +1,4 @@
-package com.profect.tickle.domain.event.scheduler;
+package com.profect.tickle.domain.notification.scheduler;
 
 import com.profect.tickle.domain.event.mapper.EventMapper;
 import jakarta.transaction.Transactional;

--- a/src/main/java/com/profect/tickle/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/profect/tickle/domain/notification/service/NotificationService.java
@@ -174,7 +174,7 @@ public class NotificationService {
         Instant now = Instant.now();
 
         String title = String.format(template.getTitle(), couponName);
-        String message = String.format(template.getContent(), couponName, expiryDate.toString(), now);
+        String message = String.format(template.getContent(), couponName, expiryDate.toString());
 
         sendSseAndSaveNotification(memberEmail, template, title, message, now);
     }

--- a/src/main/java/com/profect/tickle/domain/reservation/dto/response/reservation/ReservationDto.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/dto/response/reservation/ReservationDto.java
@@ -1,23 +1,23 @@
 package com.profect.tickle.domain.reservation.dto.response.reservation;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
-@Builder
+@Setter
 @ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReservationDto {
 
     private Long id;
     private String code;
     private Integer totalPrice;
-    private boolean isNotify;
+    private Boolean isNotify;
     @Setter
     private List<ReservedSeatDto> seatList;
 

--- a/src/main/java/com/profect/tickle/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/service/ReservationService.java
@@ -128,13 +128,16 @@ public class ReservationService {
     // 예매 성공 이벤트 발행 메서드
     private void publishReservationSuccessEvent(long reservationId, long userId) {
         PerformanceDto reservedPerformance = performanceMapper.findByReservationId(reservationId); // 예매 공연 정보
+        log.info("예약된 공연 정보: {}", reservedPerformance.getTitle());
         ReservationDto reservation = reservationMapper.findById(reservationId).orElseThrow(() -> new BusinessException(ErrorCode.RESERVATION_NOT_FOUND)); // 예매 정보
+        log.info("예약ID로 찾은 예약 정보: {}", reservation.getId());
         Member siginMember = memberRepository.findById(userId) // 예매 유저 정보
                 .orElseThrow(() -> new BusinessException(
                         ErrorCode.MEMBER_NOT_FOUND.getMessage(),
                         ErrorCode.MEMBER_NOT_FOUND)
                 );
         eventPublisher.publishEvent(new ReservationSuccessEvent(reservedPerformance, reservation, siginMember));
+        log.info("예매 성공 이벤트 발행 완료");
     }
 
     private List<Seat> validatePreemptedSeats(String preemptionToken, Long userId) {


### PR DESCRIPTION
## 📌 연관된 이슈
> close #119 


## 📝작업 내용

> 알림 미발송 오류를 수정했습니다. 원인은 DB Notification_Template의 데이터가 없었기 때문이였습니다.



## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
