### PR TITLE
refactor: 알림 조회 단위테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 
     // ===== Test Dependencies =====
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation "org.mockito:mockito-inline:5.2.0"
 
     // ===== Jwt Dependencies =====
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/test/java/com/profect/tickle/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/profect/tickle/domain/member/controller/MemberControllerTest.java
@@ -38,6 +38,7 @@ class MemberControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
     @Autowired
     private ObjectMapper objectMapper;
 

--- a/src/test/java/com/profect/tickle/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/profect/tickle/domain/notification/controller/NotificationControllerTest.java
@@ -12,13 +12,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.aot.DisabledInAotMode;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -42,42 +42,52 @@ class NotificationControllerTest {
 
     @Test
     @DisplayName("알림 조회: size 파라미터가 주어지면 해당 개수로 조회한다")
-    @WithMockMember(id = 42, email = "test@tickle.kr", roles = "MEMBER")
+    @WithMockMember(id = 42, email = "test@tickle.kr")
     void getRecentNotifications_withSizeParam() throws Exception {
+        // given
         long memberId = 42L;
         int size = 2;
 
         given(notificationService.getRecentNotificationListByMemberId(memberId, size))
                 .willReturn(Collections.emptyList());
 
-        mockMvc.perform(get("/api/v1/notifications")
-                        .param("size", String.valueOf(size))
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
+        // when
+        ResultActions result = mockMvc.perform(get("/api/v1/notifications")
+                .param("size", String.valueOf(size))
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data.length()").value(0));
 
-        verify(notificationService).getRecentNotificationListByMemberId(memberId, size);
+        then(notificationService).should()
+                .getRecentNotificationListByMemberId(memberId, size);
     }
 
     @Test
     @DisplayName("알림 조회: size 파라미터 없으면 기본값(10)으로 조회한다")
-    @WithMockMember(id = 42, email = "test@tickle.kr", roles = "MEMBER")
+    @WithMockMember(id = 42, email = "test@tickle.kr")
     void getRecentNotifications_withoutSizeParam_usesDefault10() throws Exception {
+        // given
         long memberId = 42L;
-        int defaultSize = 10;
+        int size = 10;
 
-        when(notificationService.getRecentNotificationListByMemberId(memberId, defaultSize))
-                .thenReturn(Collections.emptyList());
+        given(notificationService.getRecentNotificationListByMemberId(memberId, size))
+                .willReturn(Collections.emptyList());
 
-        mockMvc.perform(get("/api/v1/notifications")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/notifications")
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions.andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data.length()").value(0));
 
-        verify(notificationService).getRecentNotificationListByMemberId(memberId, defaultSize);
+        then(notificationService).should()
+                .getRecentNotificationListByMemberId(memberId, size);
     }
 }

--- a/src/test/java/com/profect/tickle/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/profect/tickle/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,83 @@
+package com.profect.tickle.domain.notification.controller;
+
+import com.profect.tickle.domain.chat.config.ChatJwtAuthenticationInterceptor;
+import com.profect.tickle.domain.notification.service.NotificationService;
+import com.profect.tickle.testsecurity.WithMockMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.aot.DisabledInAotMode;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(NotificationController.class)
+@DisabledInAotMode
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @MockBean
+    private ChatJwtAuthenticationInterceptor chatJwtAuthenticationInterceptor;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        given(chatJwtAuthenticationInterceptor.preHandle(any(), any(), any())).willReturn(true);
+    }
+
+    @Test
+    @DisplayName("알림 조회: size 파라미터가 주어지면 해당 개수로 조회한다")
+    @WithMockMember(id = 42, email = "test@tickle.kr", roles = "MEMBER")
+    void getRecentNotifications_withSizeParam() throws Exception {
+        long memberId = 42L;
+        int size = 2;
+
+        given(notificationService.getRecentNotificationListByMemberId(memberId, size))
+                .willReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .param("size", String.valueOf(size))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+
+        verify(notificationService).getRecentNotificationListByMemberId(memberId, size);
+    }
+
+    @Test
+    @DisplayName("알림 조회: size 파라미터 없으면 기본값(10)으로 조회한다")
+    @WithMockMember(id = 42, email = "test@tickle.kr", roles = "MEMBER")
+    void getRecentNotifications_withoutSizeParam_usesDefault10() throws Exception {
+        long memberId = 42L;
+        int defaultSize = 10;
+
+        when(notificationService.getRecentNotificationListByMemberId(memberId, defaultSize))
+                .thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+
+        verify(notificationService).getRecentNotificationListByMemberId(memberId, defaultSize);
+    }
+}

--- a/src/test/java/com/profect/tickle/testsecurity/WithMockMember.java
+++ b/src/test/java/com/profect/tickle/testsecurity/WithMockMember.java
@@ -1,0 +1,14 @@
+package com.profect.tickle.testsecurity;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+import java.lang.annotation.*;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@WithSecurityContext(factory = WithMockMemberSecurityContextFactory.class)
+public @interface WithMockMember {
+    long id() default 1L;
+    String email() default "user@example.com";
+    String[] roles() default { "MEMBER" };
+}

--- a/src/test/java/com/profect/tickle/testsecurity/WithMockMemberSecurityContextFactory.java
+++ b/src/test/java/com/profect/tickle/testsecurity/WithMockMemberSecurityContextFactory.java
@@ -1,0 +1,47 @@
+package com.profect.tickle.testsecurity;
+
+import com.profect.tickle.global.security.util.principal.CustomUserDetails;
+import org.mockito.Mockito;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class WithMockMemberSecurityContextFactory implements WithSecurityContextFactory<WithMockMember> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockMember a) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        // ✅ getAuthorities()의 시그니처에 정확히 맞춰서 타입 선언
+        Collection<? extends GrantedAuthority> authorities = Arrays.stream(a.roles())
+                .map(r -> r.startsWith("ROLE_") ? r : "ROLE_" + r)
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+
+        CustomUserDetails principal = Mockito.mock(CustomUserDetails.class);
+        Mockito.when(principal.getId()).thenReturn(a.id());
+        Mockito.when(principal.getUsername()).thenReturn(a.email());
+
+        // ✅ 1) thenReturn에 딱 맞는 타입으로 전달
+        // Mockito.when(principal.getAuthorities()).thenReturn(authorities);
+
+        // ✅ 2) 또는 doReturn(..).when(..) 패턴 사용 (제네릭 추론 이슈 회피)
+        Mockito.doReturn(authorities).when(principal).getAuthorities();
+
+        Mockito.when(principal.getPassword()).thenReturn("N/A");
+        Mockito.when(principal.isAccountNonExpired()).thenReturn(true);
+        Mockito.when(principal.isAccountNonLocked()).thenReturn(true);
+        Mockito.when(principal.isCredentialsNonExpired()).thenReturn(true);
+        Mockito.when(principal.isEnabled()).thenReturn(true);
+
+        var auth = new UsernamePasswordAuthenticationToken(principal, "N/A", authorities);
+        context.setAuthentication(auth);
+        return context;
+    }
+}


### PR DESCRIPTION
## 📌 연관된 이슈
> #131 


## 📝작업 내용

> 알림 컨트롤러의 조회 기능을 단위 테스트 했습니다. 그 과정에서 testsecurity도 추가했습니다. 참고해주세요.



## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
