### PR TITLE
refactor: Reservation-Seat 관계에서 위험한 cascade 설정 제거

### DIFF
--- a/src/main/java/com/profect/tickle/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/entity/Reservation.java
@@ -53,8 +53,7 @@ public class Reservation {
     @Column(name = "reservation_updated_at")
     private Instant updatedAt;
 
-    // 예매가 삭제 되면 좌석도 삭제 되는가? 지금의 설정에 대해 공부해보자.
-    @OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "reservation", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<Seat> seats = new ArrayList<>();
 
     public static Reservation create(Member member, Performance performance, Status status, Integer price) {

--- a/src/main/java/com/profect/tickle/domain/reservation/service/ReservationInfoService.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/service/ReservationInfoService.java
@@ -38,7 +38,7 @@ public class ReservationInfoService {
         }
 
         // 2. 총 결제 금액 계산
-        Integer totalAmount = seats.stream()
+        int totalAmount = seats.stream()
                 .mapToInt(Seat::getSeatPrice)
                 .sum();
 


### PR DESCRIPTION
## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 


## 📝작업 내용

- 예매 삭제 시 좌석 삭제를 방지하기 위해 CascadeType.REMOVE 제거
- 컬렉션에서 제거 시 좌석 삭제를 방지하기 위해 orphanRemoval=true 제거
- 안전한 작업을 위해 CascadeType.PERSIST와 CascadeType.MERGE만 유지
- 좌석은 예매 취소와 함께 삭제되지 않는 재사용 가능한 자원이어야 함


## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
