### PR TITLE
fix: 이벤트와 좌석의 연관관계 수정

### DIFF
--- a/src/main/java/com/profect/tickle/domain/event/entity/Event.java
+++ b/src/main/java/com/profect/tickle/domain/event/entity/Event.java
@@ -27,8 +27,7 @@ public class Event {
     @JoinColumn(name = "status_id", nullable = false)
     private Status status;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "seat_id", nullable = false)
+    @OneToOne(mappedBy = "event")
     private Seat seat;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/profect/tickle/domain/reservation/entity/Seat.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/entity/Seat.java
@@ -34,13 +34,13 @@ public class Seat {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "performance_id", nullable = false)
     private Performance performance;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id")
-    private Event event;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_id")

--- a/src/main/resources/mapper/event/EventMapper.xml
+++ b/src/main/resources/mapper/event/EventMapper.xml
@@ -50,7 +50,7 @@
         p.performance_start_date AS startDate,
         p.performance_end_date AS endDate
         FROM event e
-        JOIN seat s ON e.seat_id = s.seat_id
+        JOIN seat s ON e.event_id = s.event_id
         JOIN performance p ON s.performance_id = p.performance_id
         JOIN status st ON e.status_id = st.status_id
         WHERE p.performance_end_date &gt;= NOW()


### PR DESCRIPTION
## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 
- #154 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 이벤트와 좌석의 관계 카디널리티가 맞지않는 문제와, 연관관계 주인 미설정에 대한 오류를 해결하였습니다.
**수정 전**

```java
@Getter
@Entity
@Table(name = "seat")
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@AllArgsConstructor
@Builder
public class Seat {
		.
		.
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "event_id")
    private Event event;
}
```

```java
@Getter
@Entity
@Table(name = "event")
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class Event {
		.
		.
    @OneToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "seat_id", nullable = false)
    private Seat seat;
}
```

**수정 후**
```java
@Getter
@Entity
@Table(name = "seat")
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@AllArgsConstructor
@Builder
public class Seat {
		.
		.
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "event_id")
    private Event event;
}
```

```java
@Getter
@Entity
@Table(name = "event")
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class Event {
		.
		.
    @OneToOne(mappedBy = "event")
    private Seat seat;
}
```

- Event와 Seat의 연관관계 수정에 따른 mapper sql 변경

```
    <select id="findTicketEventList" resultMap="TicketListMap">
        SELECT
        e.event_id AS id,
        e.event_name AS name,
        e.event_per_price AS perPrice,
        p.performance_img AS img,
        st.status_id AS statusId,
        p.performance_start_date AS startDate,
        p.performance_end_date AS endDate
        FROM event e
        JOIN seat s ON e.event_id = s.event_id
        JOIN performance p ON s.performance_id = p.performance_id
        JOIN status st ON e.status_id = st.status_id
        WHERE p.performance_end_date &gt;= NOW()
        ORDER BY e.event_created_at DESC
        LIMIT #{size} OFFSET #{offset}
    </select>
```



## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
