### PR TITLE
fix: 쿠폰 잔여개수가 0개일 시, 이벤트 상태 변경 에러

### DIFF
--- a/src/main/java/com/profect/tickle/domain/event/entity/Coupon.java
+++ b/src/main/java/com/profect/tickle/domain/event/entity/Coupon.java
@@ -22,7 +22,7 @@ public class Coupon {
     @Column(name = "coupon_id")
     private Long id;
 
-    @OneToOne(mappedBy = "coupon", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "coupon")
     private Event event;
 
     @Column(name = "coupon_name", length = 10, nullable = false)

--- a/src/main/java/com/profect/tickle/domain/event/entity/Event.java
+++ b/src/main/java/com/profect/tickle/domain/event/entity/Event.java
@@ -5,6 +5,7 @@ import com.profect.tickle.domain.reservation.entity.Seat;
 import com.profect.tickle.global.exception.BusinessException;
 import com.profect.tickle.global.exception.ErrorCode;
 import com.profect.tickle.global.status.Status;
+import com.profect.tickle.global.status.StatusIds;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -101,8 +102,9 @@ public class Event {
     }
 
     public void accumulate(Short perPrice) {
-        if (this.status.getId() != 5) {
-            throw new BusinessException(ErrorCode.EVENT_NOT_IN_PROGRESS);}
+        if (!this.status.getId().equals(StatusIds.Event.IN_PROGRESS)) {
+            throw  new BusinessException(ErrorCode.EVENT_NOT_IN_PROGRESS);
+        }
         this.accrued += perPrice;
     }
 

--- a/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/profect/tickle/domain/event/service/impl/EventServiceImpl.java
@@ -180,20 +180,15 @@ public class EventServiceImpl implements EventService {
         Coupon coupon = event.getCoupon();
         Member member = getMemberOrThrow();
 
-        if (coupon == null) throw new BusinessException(ErrorCode.COUPON_NOT_FOUND);
+        checkDuplicateCoupon(member, coupon);
+        checkEventInProgress(event);
 
-        if (couponReceivedRepository.existsByMemberIdAndCouponId(member.getId(), coupon.getId())) {
-            throw new BusinessException(ErrorCode.ALREADY_ISSUED_COUPON);
-        }
-
-        if (coupon.getCount() <= 0) {
-            event.updateStatus(statusProvider.provide(StatusIds.Event.COMPLETED));
-            throw new BusinessException(ErrorCode.COUPON_SOLD_OUT);
-        }
-
-        coupon.decreaseCount();
         Status issuedStatus = statusProvider.provide(StatusIds.Coupon.AVAILABLE);
         couponReceivedRepository.save(CouponReceived.create(member, coupon, issuedStatus));
+
+        coupon.decreaseCount();
+
+        endEventIfCouponOutOfStock(coupon, event);
     }
 
     @Override
@@ -246,6 +241,18 @@ public class EventServiceImpl implements EventService {
         return PagingResponse.from(list, page, size, total);
     }
 
+    @Override
+    public List<ExpiringSoonCouponResponseDto> getCouponListExpiringUntil(@NotNull LocalDate untilDate) {
+        Instant now = Instant.now(clock);
+        Instant endExclusive = untilDate.plusDays(1).atStartOfDay(zone).toInstant();
+
+        if (endExclusive.isBefore(now)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        return couponMapper.findCouponListExpiringBefore(endExclusive);
+    }
+
     private Event getEventOrThrow(Long eventId) {
         return eventRepository.findById(eventId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.EVENT_NOT_FOUND));
@@ -267,15 +274,24 @@ public class EventServiceImpl implements EventService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.PERFORMANCE_NOT_FOUND));
     }
 
-    @Override
-    public List<ExpiringSoonCouponResponseDto> getCouponListExpiringUntil(@NotNull LocalDate untilDate) {
-        Instant now = Instant.now(clock);
-        Instant endExclusive = untilDate.plusDays(1).atStartOfDay(zone).toInstant();
-
-        if (endExclusive.isBefore(now)) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+    private void checkEventInProgress(Event event) {
+        if (StatusIds.Event.SCHEDULED.equals(event.getStatus().getId())) {
+            throw new BusinessException(ErrorCode.EVENT_NOT_IN_PROGRESS);
         }
+        if (StatusIds.Event.COMPLETED.equals(event.getStatus().getId())) {
+            throw new BusinessException(ErrorCode.COUPON_SOLD_OUT);
+        }
+    }
 
-        return couponMapper.findCouponListExpiringBefore(endExclusive);
+    private void checkDuplicateCoupon(Member member, Coupon coupon) {
+        if (couponReceivedRepository.existsByMemberIdAndCouponId(member.getId(), coupon.getId())) {
+            throw new BusinessException(ErrorCode.ALREADY_ISSUED_COUPON);
+        }
+    }
+
+    private void endEventIfCouponOutOfStock(Coupon coupon, Event event) {
+        if (coupon.getCount() == 0) {
+            event.updateStatus(statusProvider.provide(StatusIds.Event.COMPLETED));
+        }
     }
 }


### PR DESCRIPTION
## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 
- #156 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

쿠폰의 잔여 수량이 1개 남아있을 때, 사용자가 쿠폰을 발급받으면 이벤트의 상태가 6L로 변경되어야하는데, 계속 진행중인 상태인 5L 상태가 지속되어 테스트를 계속 실패하였다.
<img width="2048" height="579" alt="image" src="https://github.com/user-attachments/assets/d25b943b-9922-4f35-8dad-8f54808f1468" />



 **수정 전의 issueCoupon**
```java
		@Override
    @Transactional
    public void issueCoupon(Long eventId) {
        Event event = getEventOrThrow(eventId);
        Coupon coupon = event.getCoupon();
        Member member = getMemberOrThrow();

        if (couponReceivedRepository.existsByMemberIdAndCouponId(member.getId(), coupon.getId())) {
            throw new BusinessException(ErrorCode.ALREADY_ISSUED_COUPON);
        }

        if (coupon.getCount() <= 0) {
            event.updateStatus(statusProvider.provide(StatusIds.Event.COMPLETED));
            throw new BusinessException(ErrorCode.COUPON_SOLD_OUT);
        }

        coupon.decreaseCount();
        Status issuedStatus = statusProvider.provide(StatusIds.Coupon.AVAILABLE);
        couponReceivedRepository.save(CouponReceived.create(member, coupon, issuedStatus));
    }
```

코드를 다시 살펴보니, **coupon.decreaseCount();** 를 호출하여 Coupon 개수를 차감시키는데, 메서드 전에 잔여 쿠폰이 0개가 되면 다음 발급 요청에서 이벤트 상태를 변경하는 로직으로 작성하여 테스트코드 결과가 계속 이벤트 상태가 진행중으로 도출 된 것이였다.

즉, 현재는 사용자 쿠폰 발급 후 잔여 쿠폰이 0개가 되면 다음 발급 요청에서 이벤트 상태를 변경하도록 되어있는데
사용자 쿠폰 발급 후, 그 쿠폰의 개수가 0개가 되었으면 바로 이벤트 상태를 변경해주어야한다.

- 현재 로직: 중복된 쿠폰발급 확인 → 쿠폰 개수가 0개라면 이벤트 상태 종료로 변경 → 쿠폰 잔여개수 차감 → 사용자 쿠폰 지급
- 정상적인 로직: 중복된 쿠폰발급 확인 → 종료되거나 진행 전인 이벤트 여부 확인 → 사용자 쿠폰 지급 → 쿠폰 잔여개수 차감 → 쿠폰 개수가 0개라면 이벤트 상태 종료로 변경




 **수정 전의 issueCoupon**
```java
    @Override
    @Transactional
    public void issueCoupon(Long eventId) {
        Event event = getEventOrThrow(eventId);
        Coupon coupon = event.getCoupon();
        Member member = getMemberOrThrow();

        checkDuplicateCoupon(member, coupon);
        checkEventInProgress(event);

        Status issuedStatus = statusProvider.provide(StatusIds.Coupon.AVAILABLE);
        couponReceivedRepository.save(CouponReceived.create(member, coupon, issuedStatus));

        coupon.decreaseCount();

        endEventIfCouponOutOfStock(coupon, event);
    }
```



<img width="481" height="216" alt="스크린샷 2025-08-24 오전 5 38 54" src="https://github.com/user-attachments/assets/ad39ce9b-2c2d-4322-a741-2ac4bbf8b007" />

테스트를 성공적으로 수행하였다.



## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
