### PR TITLE
feat: 예약 기간이 아닐 경우 예외 처리 추가

### DIFF
--- a/src/main/java/com/profect/tickle/domain/performance/entity/Performance.java
+++ b/src/main/java/com/profect/tickle/domain/performance/entity/Performance.java
@@ -144,4 +144,7 @@ public class Performance {
         this.deletedAt = Instant.now();
     }
 
+    public boolean isReservationPeriod() {
+        return this.startDate.isBefore(Instant.now()) && this.endDate.isAfter(Instant.now());
+    }
 }

--- a/src/main/java/com/profect/tickle/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/profect/tickle/domain/reservation/service/ReservationService.java
@@ -158,6 +158,11 @@ public class ReservationService {
 
     private Reservation createReservation(List<Seat> seats, Member member, Integer price) {
         Performance performance = seats.getFirst().getPerformance();
+
+        if (!performance.isReservationPeriod()) {
+            throw new BusinessException(ErrorCode.RESERVATION_PERIOD_CLOSED);
+        }
+
         Status paidStatus = statusProvider.provide(StatusIds.Reservation.PAID);
 
         Reservation reservation = Reservation.create(member, performance, paidStatus, price);

--- a/src/main/java/com/profect/tickle/global/exception/ErrorCode.java
+++ b/src/main/java/com/profect/tickle/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     NO_PERMISSION(HttpStatus.FORBIDDEN,"공연을 삭제할 권한이 없습니다."),
     ALREADY_SCRAPPED(HttpStatus.CONFLICT,"이미 스크랩된 공연입니다."),
     FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND,"스크랩된 공연이 존재하지 않습니다."),
+    RESERVATION_PERIOD_CLOSED(HttpStatus.BAD_REQUEST, "예매 기간이 아닙니다."),
 
     //SEAT
     SEAT_CLASS_NOT_FOUND(HttpStatus.NOT_FOUND, "좌석 등급 정보를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 연관된 이슈
#161 

## 📝작업 내용

- 예약 서비스에 예매 가능 기간 확인 로직 추가
- Performance 엔티티에 예매 가능 기간 확인 메서드(isReservationPeriod) 구현
- 예약 기간이 아닐 경우 예외를 발생시키도록 수정 (RESERVATION_PERIOD_CLOSED)


## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
