### PR TITLE
chore: 불필요 지표였던 connection_error에 관한 메트릭 제거

### DIFF
--- a/src/test/java/com/profect/tickle/domain/notification/performance/SseCapacitySweep.js
+++ b/src/test/java/com/profect/tickle/domain/notification/performance/SseCapacitySweep.js
@@ -22,7 +22,7 @@ const stayedFull = new Rate("sse_stayed_full");
 const connAlive = new Trend("sse_conn_alive_ms");
 const earlyClose = new Counter("sse_early_close");
 const messagesReceived = new Counter("sse_messages_received");
-const latency = new Trend("latency(ms)");
+const latency = new Trend("latency");
 const connectionRetries = new Counter("sse_connection_retries");
 const sessionsCompleted = new Counter("sse_sessions_completed");
 
@@ -245,7 +245,7 @@ export function teardown() {
   console.log("- sse_open_ok: Connection success rate");
   console.log("- sse_stayed_full: Session completion rate");
   console.log("- sse_messages_received: Total messages processed");
-  console.log("- sse_connection_errors: Error count");
+  // console.log("- sse_connection_errors: Error count");
   console.log("- latency: First message response time");
   console.log("- sse_sessions_completed: Successfully completed sessions");
   console.log("- sse_conn_alive_ms: Connection duration time");

--- a/src/test/java/com/profect/tickle/domain/notification/performance/config.js
+++ b/src/test/java/com/profect/tickle/domain/notification/performance/config.js
@@ -15,7 +15,6 @@ const configs = {
       sse_open_ok: ["rate>0.90"],
       sse_stayed_full: ["rate>0.80"],
       sse_conn_alive_ms: ["p(95)<30000"],
-      sse_connection_errors: ["count<10"],
       latency: ["p(95)<5000"], // 변경: sse_time_to_first_message → latency
     },
   },
@@ -35,7 +34,6 @@ const configs = {
       sse_open_ok: ["rate>0.95"],
       sse_stayed_full: ["rate>0.90"],
       sse_conn_alive_ms: ["p(95)<60000"],
-      sse_connection_errors: ["count<15"],
       latency: ["p(95)<3000"], // 변경: sse_time_to_first_message → latency
     },
   },
@@ -56,7 +54,6 @@ const configs = {
       sse_open_ok: ["rate>0.98"], // 98% 이상 연결 성공
       sse_stayed_full: ["rate>0.95"], // 95% 이상 세션 완료
       sse_conn_alive_ms: ["p(95)<65000"], // 60초 + 5초 여유
-      sse_connection_errors: ["count<10"], // 에러 10개 이하
       latency: ["p(95)<2000"], // 변경: sse_time_to_first_message → latency (첫 메시지 2초 이내)
     },
   },
@@ -85,9 +82,6 @@ const configs = {
         ],
         sse_conn_alive_ms: [
           `p(95)<${Math.min(90000, 65000 + (scaleFactor - 1) * 5000)}`,
-        ],
-        sse_connection_errors: [
-          `count<${Math.min(50, Math.ceil(10 * scaleFactor))}`,
         ],
         latency: [`p(95)<${Math.min(5000, 2000 + (scaleFactor - 1) * 500)}`],
       },


### PR DESCRIPTION
## 📌 연관된 이슈
> #216 