### PR TITLE
fix: Redis LettuceConnectionFactory 초기화 오류 해결

### DIFF
--- a/src/main/java/com/profect/tickle/global/redis/config/RedisConfig.java
+++ b/src/main/java/com/profect/tickle/global/redis/config/RedisConfig.java
@@ -34,10 +34,10 @@ import java.time.Duration;
 @EnableRetry
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String host;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int port;
 
     @Value("${spring.redis.password}")
@@ -83,7 +83,12 @@ public class RedisConfig {
                 .poolConfig(new GenericObjectPoolConfig<>())
                 .build();
 
-        return new LettuceConnectionFactory(redisConfig, clientConfig);
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(
+                redisConfig, clientConfig);
+
+        factory.afterPropertiesSet();
+
+        return factory;
     }
 
     /**


### PR DESCRIPTION
- redisConnectionFactory()에서 afterPropertiesSet() 호출 누락으로 인한 "LettuceConnectionFactory has been CREATED. Use start() to initialize it" 오류 수정
- LettuceConnectionFactory 수동 생성 시 필수 초기화 단계 추가

## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요



## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
