### PR TITLE
fix: Redis 설정 프로퍼티 경로를 Spring Boot 표준으로 수정

### DIFF
--- a/src/main/java/com/profect/tickle/global/redis/config/RedisConfig.java
+++ b/src/main/java/com/profect/tickle/global/redis/config/RedisConfig.java
@@ -40,7 +40,7 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
-    @Value("${spring.redis.password}")
+    @Value("${spring.data.redis.password}")
     private String password;
 
     private static final String REDISSON_HOST_PREFIX = "redis://";


### PR DESCRIPTION
- spring.redis.password → spring.data.redis.password로 변경
- Spring Boot 자동 설정과 일관성 유지

## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요



## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
